### PR TITLE
Support for URI Handler

### DIFF
--- a/RomM.cs
+++ b/RomM.cs
@@ -159,11 +159,6 @@ namespace RomM
                         // We always open the game in the webview
                         return;
                     }
-                    else if (action == "install")
-                    {
-                        InstallController installController = game.GetRomMGameInfo().GetInstallController(game, this);
-                        installController.Install(new InstallActionArgs() { });
-                    }
                     else if (action == "play")
                     {
                         PlayniteApi.StartGame(game.Id);


### PR DESCRIPTION
Add URI handler for games installed in the romm library. URL is in the format `playnite://romm/<action>/<platform_igdb_id>/<rom_id>`, where supported actions are `view` and `play`. The path element `platform_igdb_id` is currently required since the endpoint to fetch a single rom doesn't return it.