### PR TITLE
feat/perf: performance, naming and code quality improvements

### DIFF
--- a/Models/RomM/Platform/RomMPlatform.cs
+++ b/Models/RomM/Platform/RomMPlatform.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace RomM.Models.RomM.Platform
+{
+public class RomMPlatform
+    {
+        [JsonProperty("id")]
+        public int Id { get; set; }
+
+        [JsonProperty("slug")]
+        public string Slug { get; set; }
+
+        [JsonProperty("fs_slug")]
+        public string FsSlug { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("rom_count")]
+        public int RomCount { get; set; }
+
+        [JsonProperty("igdb_id")]
+        public ulong IgdbId { get; set; }
+
+        [JsonProperty("sgdb_id")]
+        public object SgdbId { get; set; }
+
+        [JsonProperty("moby_id")]
+        public object MobyId { get; set; }
+
+        [JsonProperty("logo_path")]
+        public string LogoPath { get; set; }
+
+        [JsonProperty("firmware")]
+        public List<RomMPlatformFirmware> Firmware { get; set; }
+
+        [JsonProperty("created_at")]
+        public DateTime CreatedAt { get; set; }
+
+        [JsonProperty("updated_at")]
+        public DateTime UpdatedAt { get; set; }
+    }
+
+
+}

--- a/Models/RomM/Platform/RomMPlatformFirmware.cs
+++ b/Models/RomM/Platform/RomMPlatformFirmware.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace RomM.Models.RomM.Platform
+{
+    public class RomMPlatformFirmware
+    {
+        [JsonProperty("id")]
+        public int Id { get; set; }
+
+        [JsonProperty("file_name")]
+        public string FileName { get; set; }
+
+        [JsonProperty("file_name_no_tags")]
+        public string FileNameNoTags { get; set; }
+
+        [JsonProperty("file_name_no_ext")]
+        public string FileNameNoExt { get; set; }
+
+        [JsonProperty("file_extension")]
+        public string FileExtension { get; set; }
+
+        [JsonProperty("file_path")]
+        public string FilePath { get; set; }
+
+        [JsonProperty("file_size_bytes")]
+        public int FileSizeBytes { get; set; }
+
+        [JsonProperty("full_path")]
+        public string FullPath { get; set; }
+
+        [JsonProperty("is_verified")]
+        public bool IsVerified { get; set; }
+
+        [JsonProperty("crc_hash")]
+        public string CrcHash { get; set; }
+
+        [JsonProperty("md5_hash")]
+        public string Md5Hash { get; set; }
+
+        [JsonProperty("sha1_hash")]
+        public string Sha1Hash { get; set; }
+
+        [JsonProperty("created_at")]
+        public DateTime CreatedAt { get; set; }
+
+        [JsonProperty("updated_at")]
+        public DateTime UpdatedAt { get; set; }
+    }
+}

--- a/Models/RomM/Rom/RomMDLC.cs
+++ b/Models/RomM/Rom/RomMDLC.cs
@@ -1,0 +1,22 @@
+﻿using Newtonsoft.Json;
+
+namespace RomM.Models.RomM.Rom
+{
+    public class RomMDLC
+    {
+        [JsonProperty("id")]
+        public int Id { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("slug")]
+        public string Slug { get; set; }
+
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        [JsonProperty("cover_url")]
+        public string CoverUrl { get; set; }
+    }
+}

--- a/Models/RomM/Rom/RomMExpandedGame.cs
+++ b/Models/RomM/Rom/RomMExpandedGame.cs
@@ -1,0 +1,22 @@
+﻿using Newtonsoft.Json;
+
+namespace RomM.Models.RomM.Rom
+{
+    public class RomMExpandedGame
+    {
+        [JsonProperty("id")]
+        public int Id { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("slug")]
+        public string Slug { get; set; }
+
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        [JsonProperty("cover_url")]
+        public string CoverUrl { get; set; }
+    }
+}

--- a/Models/RomM/Rom/RomMExpansion.cs
+++ b/Models/RomM/Rom/RomMExpansion.cs
@@ -1,0 +1,22 @@
+﻿using Newtonsoft.Json;
+
+namespace RomM.Models.RomM.Rom
+{
+    public class RomMExpansion
+    {
+        [JsonProperty("id")]
+        public int Id { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("slug")]
+        public string Slug { get; set; }
+
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        [JsonProperty("cover_url")]
+        public string CoverUrl { get; set; }
+    }
+}

--- a/Models/RomM/Rom/RomMIgdbMetadata.cs
+++ b/Models/RomM/Rom/RomMIgdbMetadata.cs
@@ -1,0 +1,59 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace RomM.Models.RomM.Rom
+{
+    public class RomMIgdbMetadata
+    {
+        [JsonProperty("total_rating")]
+        public string TotalRating { get; set; }
+
+        [JsonProperty("aggregated_rating")]
+        public string AggregatedRating { get; set; }
+
+        [JsonProperty("first_release_date")]
+        public int? FirstReleaseDate { get; set; }
+
+        [JsonProperty("genres")]
+        public List<string> Genres { get; set; }
+
+        [JsonProperty("franchises")]
+        public List<string> Franchises { get; set; }
+
+        [JsonProperty("alternative_names")]
+        public List<string> AlternativeNames { get; set; }
+
+        [JsonProperty("collections")]
+        public List<string> Collections { get; set; }
+
+        [JsonProperty("companies")]
+        public List<string> Companies { get; set; }
+
+        [JsonProperty("game_modes")]
+        public List<string> GameModes { get; set; }
+
+        [JsonProperty("platforms")]
+        public List<RomMRomPlatform> Platforms { get; set; }
+
+        [JsonProperty("expansions")]
+        public List<RomMExpansion> Expansions { get; set; }
+
+        [JsonProperty("dlcs")]
+        public List<RomMDLC> Dlcs { get; set; }
+
+        [JsonProperty("remasters")]
+        public List<RomMRemaster> Remasters { get; set; }
+
+        [JsonProperty("remakes")]
+        public List<RomMRemake> Remakes { get; set; }
+
+        [JsonProperty("expanded_games")]
+        public List<RomMExpandedGame> ExpandedGames { get; set; }
+
+        [JsonProperty("ports")]
+        public List<RomMPort> Ports { get; set; }
+
+        [JsonProperty("similar_games")]
+        public List<RomMSimilarGame> SimilarGames { get; set; }
+    }
+}

--- a/Models/RomM/Rom/RomMPort.cs
+++ b/Models/RomM/Rom/RomMPort.cs
@@ -1,0 +1,22 @@
+﻿using Newtonsoft.Json;
+
+namespace RomM.Models.RomM.Rom
+{
+    public class RomMPort
+    {
+        [JsonProperty("id")]
+        public int Id { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("slug")]
+        public string Slug { get; set; }
+
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        [JsonProperty("cover_url")]
+        public string CoverUrl { get; set; }
+    }
+}

--- a/Models/RomM/Rom/RomMRemake.cs
+++ b/Models/RomM/Rom/RomMRemake.cs
@@ -1,0 +1,22 @@
+﻿using Newtonsoft.Json;
+
+namespace RomM.Models.RomM.Rom
+{
+    public class RomMRemake
+    {
+        [JsonProperty("id")]
+        public int Id { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("slug")]
+        public string Slug { get; set; }
+
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        [JsonProperty("cover_url")]
+        public string CoverUrl { get; set; }
+    }
+}

--- a/Models/RomM/Rom/RomMRemaster.cs
+++ b/Models/RomM/Rom/RomMRemaster.cs
@@ -1,0 +1,22 @@
+﻿using Newtonsoft.Json;
+
+namespace RomM.Models.RomM.Rom
+{
+    public class RomMRemaster
+    {
+        [JsonProperty("id")]
+        public int Id { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("slug")]
+        public string Slug { get; set; }
+
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        [JsonProperty("cover_url")]
+        public string CoverUrl { get; set; }
+    }
+}

--- a/Models/RomM/Rom/RomMRom.cs
+++ b/Models/RomM/Rom/RomMRom.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace RomM.Models.RomM.Rom
+{
+    public class RomMRom
+    {
+        [JsonProperty("id")]
+        public int Id { get; set; }
+
+        [JsonProperty("igdb_id")]
+        public int? IgdbId { get; set; }
+
+        [JsonProperty("sgdb_id")]
+        public object SgdbId { get; set; }
+
+        [JsonProperty("moby_id")]
+        public object MobyId { get; set; }
+
+        [JsonProperty("platform_id")]
+        public int PlatformId { get; set; }
+
+        [JsonProperty("platform_slug")]
+        public string PlatformSlug { get; set; }
+
+        [JsonProperty("platform_name")]
+        public string PlatformName { get; set; }
+
+        [JsonProperty("file_name")]
+        public string FileName { get; set; }
+
+        [JsonProperty("file_name_no_tags")]
+        public string FileNameNoTags { get; set; }
+
+        [JsonProperty("file_name_no_ext")]
+        public string FileNameNoExt { get; set; }
+
+        [JsonProperty("file_extension")]
+        public string FileExtension { get; set; }
+
+        [JsonProperty("file_path")]
+        public string FilePath { get; set; }
+
+        [JsonProperty("file_size_bytes")]
+        public ulong FileSizeBytes { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("slug")]
+        public string Slug { get; set; }
+
+        [JsonProperty("summary")]
+        public string Summary { get; set; }
+
+        [JsonProperty("first_release_date")]
+        public int? FirstReleaseDate { get; set; }
+
+        [JsonProperty("alternative_names")]
+        public List<string> AlternativeNames { get; set; }
+
+        [JsonProperty("genres")]
+        public List<string> Genres { get; set; }
+
+        [JsonProperty("franchises")]
+        public List<string> Franchises { get; set; }
+
+        [JsonProperty("collections")]
+        public List<string> Collections { get; set; }
+
+        [JsonProperty("companies")]
+        public List<string> Companies { get; set; }
+
+        [JsonProperty("game_modes")]
+        public List<string> GameModes { get; set; }
+
+        [JsonProperty("igdb_metadata")]
+        public RomMIgdbMetadata IgdbMetadata { get; set; }
+
+        [JsonProperty("path_cover_s")]
+        public string PathCoverS { get; set; }
+
+        [JsonProperty("path_cover_l")]
+        public string PathCoverL { get; set; }
+
+        [JsonProperty("has_cover")]
+        public bool HasCover { get; set; }
+
+        [JsonProperty("url_cover")]
+        public string UrlCover { get; set; }
+
+        [JsonProperty("revision")]
+        public string Revision { get; set; }
+
+        [JsonProperty("regions")]
+        public List<string> Regions { get; set; }
+
+        [JsonProperty("languages")]
+        public List<string> Languages { get; set; }
+
+        [JsonProperty("tags")]
+        public List<string> Tags { get; set; }
+
+        [JsonProperty("multi")]
+        public bool Multi { get; set; }
+
+        [JsonProperty("files")]
+        public List<object> Files { get; set; }
+
+        [JsonProperty("full_path")]
+        public string FullPath { get; set; }
+
+        [JsonProperty("created_at")]
+        public DateTime CreatedAt { get; set; }
+
+        [JsonProperty("updated_at")]
+        public DateTime UpdatedAt { get; set; }
+
+        [JsonProperty("rom_user")]
+        public object RomUser { get; set; }
+
+        [JsonProperty("sort_comparator")]
+        public string SortComparator { get; set; }
+    }
+}

--- a/Models/RomM/Rom/RomMRomPlatform.cs
+++ b/Models/RomM/Rom/RomMRomPlatform.cs
@@ -1,0 +1,13 @@
+﻿using Newtonsoft.Json;
+
+namespace RomM.Models.RomM.Rom
+{
+    public class RomMRomPlatform
+    {
+        [JsonProperty("igdb_id")]
+        public int IgdbId { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+    }
+}

--- a/Models/RomM/Rom/RomMSimilarGame.cs
+++ b/Models/RomM/Rom/RomMSimilarGame.cs
@@ -1,0 +1,22 @@
+﻿using Newtonsoft.Json;
+
+namespace RomM.Models.RomM.Rom
+{
+    public class RomMSimilarGame
+    {
+        [JsonProperty("id")]
+        public int Id { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("slug")]
+        public string Slug { get; set; }
+
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        [JsonProperty("cover_url")]
+        public string CoverUrl { get; set; }
+    }
+}

--- a/RomM.cs
+++ b/RomM.cs
@@ -307,14 +307,14 @@ namespace RomM
                             continue;
                         }
 
-                        var gameNameExtended = $"{gameName}{(item.Regions.Count > 0 ? $" ({string.Join(", ", item.Regions)})" : "")}{(!string.IsNullOrEmpty(item.Revision) ? $" (Rev {item.Revision})" : "")}{(item.Tags.Count > 0 ? $" ({string.Join(", ", item.Tags)})" : "")}";
+                        var gameNameWithTags  = $"{gameName}{(item.Regions.Count > 0 ? $" ({string.Join(", ", item.Regions)})" : "")}{(!string.IsNullOrEmpty(item.Revision) ? $" (Rev {item.Revision})" : "")}{(item.Tags.Count > 0 ? $" ({string.Join(", ", item.Tags)})" : "")}";
 
                         // Add newly found game
                         games.Add(new GameMetadata
                         {
                             Source = SourceName,
-                            Name = gameNameExtended,
-                            Roms = new List<GameRom> { new GameRom(gameNameExtended, pathToGame) },
+                            Name = gameNameWithTags ,
+                            Roms = new List<GameRom> { new GameRom(gameNameWithTags , pathToGame) },
                             InstallDirectory = installDir,
                             IsInstalled = File.Exists(pathToGame),
                             GameId = gameId,

--- a/RomM.cs
+++ b/RomM.cs
@@ -307,7 +307,7 @@ namespace RomM
                             continue;
                         }
 
-                        var gameNameExtended = $"{gameName}{(item.Regions.Count > 0 ? $" ({string.Join(", ", item.Regions)})" : "")}{(!string.IsNullOrEmpty(item.Revision) ? $" ({item.Revision})" : "")}{(item.Tags.Count > 0 ? $" ({string.Join(", ", item.Tags)})" : "")}";
+                        var gameNameExtended = $"{gameName}{(item.Regions.Count > 0 ? $" ({string.Join(", ", item.Regions)})" : "")}{(!string.IsNullOrEmpty(item.Revision) ? $" (Rev {item.Revision})" : "")}{(item.Tags.Count > 0 ? $" ({string.Join(", ", item.Tags)})" : "")}";
 
                         // Add newly found game
                         games.Add(new GameMetadata

--- a/RomM.csproj
+++ b/RomM.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="Current" Sdk="Microsoft.NET.Sdk" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -71,7 +71,7 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="PlayniteSDK" Version="6.11.0" />
     <PackageReference Include="protobuf-net" Version="2.0.0.668" />
     <PackageReference Include="SharpCompress" Version="0.36.0" />

--- a/RomM.csproj
+++ b/RomM.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="Current" Sdk="Microsoft.NET.Sdk" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -71,7 +71,7 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="PlayniteSDK" Version="6.11.0" />
     <PackageReference Include="protobuf-net" Version="2.0.0.668" />
     <PackageReference Include="SharpCompress" Version="0.36.0" />

--- a/Settings/SettingsView.xaml.cs
+++ b/Settings/SettingsView.xaml.cs
@@ -1,4 +1,4 @@
-﻿﻿using System;
+﻿using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Windows;
@@ -31,16 +31,14 @@ namespace RomM.Settings
         {
             var mapping = ((FrameworkElement)sender).DataContext as EmulatorMapping;
             string path;
-            if ((path = GetSelectedFolderPath()) != null)
+            if ((path = GetSelectedFolderPath()) == null) return;
+            var playnite = SettingsViewModel.Instance.PlayniteAPI;
+            if (playnite.Paths.IsPortable)
             {
-                var playnite = SettingsViewModel.Instance.PlayniteAPI;
-                if (playnite.Paths.IsPortable)
-                {
-                    path = path.Replace(playnite.Paths.ApplicationPath, Playnite.SDK.ExpandableVariables.PlayniteDirectory);
-                }
-
-                mapping.DestinationPath = path;
+                path = path.Replace(playnite.Paths.ApplicationPath, Playnite.SDK.ExpandableVariables.PlayniteDirectory);
             }
+
+            mapping.DestinationPath = path;
         }
 
         private static string GetSelectedFolderPath()


### PR DESCRIPTION
# Changes

- Replace Newtonsoft JArray/JObject to avoid reflection and use typed objects for everything (huge performance boost)
- Return the whole array in GetGames instead yielding over the array because it has no advantage here
- Simplify LINQ queries to avoid doing Where().Any() and Where().FirstOrDefault()
- Streaming the roms http body response as for big libraries reading the whole body into memory directly is more memory inefficient
- Invert if logic in SettingsView to reduce nesting (8c41cdae20170a9c16bd92b817077b2ab42a37b9)
- ~~Bump Netwonsoft from v10 -> v13, there are no relevant breaking changes for this plugin (4359f07382d3b7efd002b3751b2475cfde0dd284)~~ Reverted because of incompatibility with Playnite
- Add Region, Revision and Tags into the Game name to make it easy inside Playnite to difference between multiple version of the same game