### PR TITLE
fix(igdb_id): make it nullable

### DIFF
--- a/Models/RomM/Platform/RomMPlatform.cs
+++ b/Models/RomM/Platform/RomMPlatform.cs
@@ -22,7 +22,7 @@ public class RomMPlatform
         public int RomCount { get; set; }
 
         [JsonProperty("igdb_id")]
-        public ulong IgdbId { get; set; }
+        public ulong? IgdbId { get; set; }
 
         [JsonProperty("sgdb_id")]
         public object SgdbId { get; set; }

--- a/Models/RomM/Rom/RomMRomPlatform.cs
+++ b/Models/RomM/Rom/RomMRomPlatform.cs
@@ -5,7 +5,7 @@ namespace RomM.Models.RomM.Rom
     public class RomMRomPlatform
     {
         [JsonProperty("igdb_id")]
-        public int IgdbId { get; set; }
+        public int? IgdbId { get; set; }
 
         [JsonProperty("name")]
         public string Name { get; set; }


### PR DESCRIPTION
This fixes an issue reported on the discord when a Platform has no igdb_id 
![image](https://github.com/user-attachments/assets/5ea93322-f274-46ec-8658-9600f18d50f9)
