### PR TITLE
fix: ensure rom installation paths are initialized correctly upon import

### DIFF
--- a/RomM.cs
+++ b/RomM.cs
@@ -279,7 +279,7 @@ namespace RomM
 
                     Logger.Debug($"Finished parsing response for {apiPlatform.Name}.");
 
-                    var installDir = PlayniteApi.Paths.IsPortable
+                    var rootInstallDir = PlayniteApi.Paths.IsPortable
                         ? mapping.DestinationPathResolved.Replace(PlayniteApi.Paths.ApplicationPath, ExpandableVariables.PlayniteDirectory)
                         : mapping.DestinationPathResolved;
 
@@ -289,7 +289,8 @@ namespace RomM
                         var gameName = item.Name;
                         var fileName = item.FileName;
                         var urlCover = item.UrlCover;
-                        var pathToGame = Path.Combine(installDir, fileName);
+                        var gameInstallDir = Path.Combine(rootInstallDir, Path.GetFileNameWithoutExtension(fileName));
+                        var pathToGame = Path.Combine(gameInstallDir, fileName);
 
                         var info = new RomMGameInfo
                         {
@@ -313,9 +314,9 @@ namespace RomM
                         games.Add(new GameMetadata
                         {
                             Source = SourceName,
-                            Name = gameNameWithTags ,
-                            Roms = new List<GameRom> { new GameRom(gameNameWithTags , pathToGame) },
-                            InstallDirectory = installDir,
+                            Name = gameNameWithTags,
+                            Roms = new List<GameRom> { new GameRom(gameNameWithTags, pathToGame) },
+                            InstallDirectory = gameInstallDir,
                             IsInstalled = File.Exists(pathToGame),
                             GameId = gameId,
                             Platforms = new HashSet<MetadataProperty> { new MetadataNameProperty(mapping.Platform.Name ?? "") },


### PR DESCRIPTION
Fixes #12

Currently when roms are imported the installation path of each game is incorrectly set to the root destination path of the emulator path mapping. A rom entry is also created with another incorrect path - this path differs from the actual path that is later assigned upon rom install. This behavior conflicts with the Installation Status Updater plugin and causes all imported roms to be marked as installed if the root destination path contains at least one file at import time.

This PR ensures that both installation and rom paths are correctly initialized on initial library import. This fixes compatibility with the Installation Status Updater plugin.

Configured mappings:
![mappings](https://github.com/user-attachments/assets/cd65e50d-0e3d-4f8b-85ee-80e7af5074ca)

Paths on import:
![import](https://github.com/user-attachments/assets/84e3ae98-7926-4052-affe-9c2af2376ddf)

Paths post install:
![postinstall](https://github.com/user-attachments/assets/5ecca449-a262-4ef4-8e06-60f07c4e7fb7)
