### PR TITLE
GH-43: Use gameName instead of gameNameWithTags

### DIFF
--- a/RomM.cs
+++ b/RomM.cs
@@ -353,7 +353,7 @@ namespace RomM
                         games.Add(new GameMetadata
                         {
                             Source = SourceName,
-                            Name = gameNameWithTags,
+                            Name = gameName,
                             Roms = new List<GameRom> { new GameRom(gameNameWithTags, pathToGame) },
                             InstallDirectory = gameInstallDir,
                             IsInstalled = File.Exists(pathToGame),


### PR DESCRIPTION
Tags are available in the ROM name, including the tags in the game name is undesirable and breaks other features like looking up metadata.

Fixes #43.

## Testing

I built the extension DLL and replaced the version in use by Playnite. After import the games all have the correct titles now without the tags. HowLongToBeat (and metadata tools) successfully look up the games now.