### PR TITLE
Check mappings UseM3u is enabled 

### DIFF
--- a/Games/RomMInstallController.cs
+++ b/Games/RomMInstallController.cs
@@ -102,18 +102,16 @@ namespace RomM.Games
                         List<string> supportedFileTypes = GetEmulatorSupportedFileTypes(info);
                         string[] actualRomFiles = GetRomFiles(installDir, supportedFileTypes);
 
-                        var m3uFile = info.Mapping.Usem3u
-                            ? Directory.EnumerateFiles(installDir, "*", SearchOption.AllDirectories)
-                                .FirstOrDefault(f => f.EndsWith(".m3u", StringComparison.OrdinalIgnoreCase))
-                            : null;
+                        var m3uFile = info.Mapping.UseM3u ? actualRomFiles.FirstOrDefault(m => m.EndsWith(".m3u")) : null;
 
-                        if (m3uFile != null)
-                        {
+                        if (m3uFile != null && info.Mapping.UseM3u)
+                            {
                             roms.Add(new GameRom(Game.Name, m3uFile));
                         }
                         else
                         {
-                            roms.AddRange(actualRomFiles.Select(f => new GameRom(Game.Name, f)));
+                            var actualRomFilesNoM3u = actualRomFiles.Where(r => !r.EndsWith(".m3u"));
+                            roms.AddRange(actualRomFilesNoM3u.Select(f => new GameRom(Game.Name, f)));
                         }
                     } 
                     else 


### PR DESCRIPTION
-Check UseM3u is enabled in the mapping before using it
-Remove m3u entry when importing games and m3u is not enabled

-Search the string array instead of the directory for m3u
`31-01 07:49:35.890|INFO |RomM#RomMInstallController:Directory search took 1630 ticks`
`31-01 07:49:35.890|INFO |RomM#RomMInstallController:actualRomFiles search took 324 ticks`