### PR TITLE
Fix incorrectly merged 7z & use more metadata

### DIFF
--- a/Downloads/DownloadQueueController.cs
+++ b/Downloads/DownloadQueueController.cs
@@ -215,10 +215,19 @@ namespace RomM.Downloads
 
         private void ExtractArchiveWith7z(string pathTo7z, string archivePath, string installDir, DownloadQueueItem item, CancellationToken ct)
         {
+            if (archivePath == null || archivePath.Contains("../") || archivePath.Contains(@"..\"))
+            {
+                throw new ArgumentException("Invalid archive path");
+            }
+            if (installDir == null || installDir.Contains("../") || installDir.Contains(@"..\"))
+            {
+                throw new ArgumentException("Invalid install directory path");
+            }
+
             ProcessStartInfo startInfo = new ProcessStartInfo
             {
                 FileName = pathTo7z,
-                Arguments = $"x \"{archivePath}\" -o\"{installDir}\" -y",
+                Arguments = $"x \"{archivePath.Replace("\"", "\\\"")}\" -o\"{installDir.Replace("\"", "\\\"")}\" -y",
                 UseShellExecute = false,
                 CreateNoWindow = true
             };

--- a/Downloads/DownloadQueueController.cs
+++ b/Downloads/DownloadQueueController.cs
@@ -3,6 +3,7 @@ using Playnite.SDK.Plugins;
 using SharpCompress.Archives;
 using SharpCompress.Common;
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -179,8 +180,15 @@ namespace RomM.Downloads
             if (req.HasMultipleFiles || (req.AutoExtract && IsFileCompressed(req.GamePath)))
             {
                 item.SetStatus(DownloadStatus.Extracting, "Extracting...");
-                ExtractArchiveWithEntryProgress(req.GamePath, req.InstallDir, item, ct);
 
+                if(req.Use7z && !string.IsNullOrEmpty(req.PathTo7Z) && req.PathTo7Z.EndsWith("7z.exe", StringComparison.OrdinalIgnoreCase))
+                {
+                    ExtractArchiveWith7z(req.PathTo7Z, req.GamePath, req.InstallDir, item, ct);
+                }
+                else
+                {
+                    ExtractArchiveWithEntryProgress(req.GamePath, req.InstallDir, item, ct);
+                }
                 try { File.Delete(req.GamePath); } catch { }
             }
 
@@ -204,6 +212,27 @@ namespace RomM.Downloads
             return ArchiveFactory.IsArchive(filePath, out var type);
         }
 
+
+        private void ExtractArchiveWith7z(string pathTo7z, string archivePath, string installDir, DownloadQueueItem item, CancellationToken ct)
+        {
+            ProcessStartInfo startInfo = new ProcessStartInfo
+            {
+                FileName = pathTo7z,
+                Arguments = $"x \"{archivePath}\" -o\"{installDir}\" -y",
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+            ct.ThrowIfCancellationRequested();
+            using (Process process = Process.Start(startInfo))
+            { 
+                process.WaitForExit();
+                if (process.ExitCode != 0)
+                {
+                    throw new Exception($"7z extraction failed for {archivePath} with exit code {process.ExitCode}.");
+                }
+            }
+        }
         private void ExtractArchiveWithEntryProgress(string archivePath, string installDir, DownloadQueueItem item, CancellationToken ct)
         {
             using (var archive = ArchiveFactory.Open(archivePath))

--- a/Downloads/DownloadRequest.cs
+++ b/Downloads/DownloadRequest.cs
@@ -14,6 +14,9 @@ namespace RomM.Downloads
         public string GamePath { get; set; }        // full path to the downloaded file on disk
         public bool HasMultipleFiles { get; set; }  // whether archive contains multiple top-level files
         public bool AutoExtract { get; set; } = true;
+        public bool Use7z { get; set; } = false;
+        public string PathTo7Z { get; set; } = "";
+
 
         /// Optional function used after extraction to build rom list for Playnite
         public Func<List<GameRom>> BuildRoms { get; set; }

--- a/Games/RomMInstallController.cs
+++ b/Games/RomMInstallController.cs
@@ -7,7 +7,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Diagnostics;
 
 namespace RomM.Games
 {
@@ -46,6 +45,8 @@ namespace RomM.Games
                 DownloadUrl = info.DownloadUrl,
                 InstallDir = installDir,
                 GamePath = downloadFilePath,
+                Use7z = _romM.Settings.Use7z,
+                PathTo7Z = _romM.Settings.PathTo7z,
 
                 HasMultipleFiles = info.HasMultipleFiles,
                 AutoExtract = info.Mapping != null && info.Mapping.AutoExtract,
@@ -77,50 +78,6 @@ namespace RomM.Games
                     {
                         var m3uFile = actualRomFiles.FirstOrDefault(m =>
                             m.EndsWith(".m3u", StringComparison.OrdinalIgnoreCase));
-
-                    Logger.Debug($"Downloading {Game.Name} to {gamePath}...");
-                    Directory.CreateDirectory(installDir);
-
-                    // Stream the file directly to disk
-                    using (var fileStream = new FileStream(gamePath, FileMode.Create, FileAccess.Write, FileShare.None, 8192, true))
-                    using (var httpStream = await response.Content.ReadAsStreamAsync())
-                    {
-                        byte[] buffer = new byte[65536];
-                        int bytesRead;
-
-                        while ((bytesRead = await httpStream.ReadAsync(buffer, 0, buffer.Length, _watcherToken.Token)) > 0)
-                        {
-                            await fileStream.WriteAsync(buffer, 0, bytesRead, _watcherToken.Token);
-                        }
-                    }
-
-                    Logger.Debug($"Download of {Game.Name} complete.");
-
-                    // Always extract top-level file of multi-file archives
-                    if (info.HasMultipleFiles || (info.Mapping.AutoExtract && IsFileCompressed(gamePath)))
-                    {
-                        Logger.Debug($"Extracting {Game.Name} to {installDir}...");
-                        // Extract the archive to the install directory
-                        ExtractArchive(gamePath, installDir);
-
-                        // Delete the compressed file
-                        File.Delete(gamePath);
-
-                        // Extract nested archives if auto-extract is enabled
-                        if (info.HasMultipleFiles && info.Mapping.AutoExtract)
-                        {
-                            ExtractNestedArchives(installDir);
-                        }
-
-                        Logger.Debug($"Extraction of {Game.Name} complete.");
-
-                        List<string> supportedFileTypes = GetEmulatorSupportedFileTypes(info);
-                        string[] actualRomFiles = GetRomFiles(installDir, supportedFileTypes);
-
-                        var m3uFile = info.Mapping.UseM3u
-                            ? Directory.EnumerateFiles(installDir, "*", SearchOption.AllDirectories)
-                                .FirstOrDefault(f => f.EndsWith(".m3u", StringComparison.OrdinalIgnoreCase))
-                            : null;
 
                         if (!string.IsNullOrEmpty(m3uFile))
                         {
@@ -228,74 +185,6 @@ namespace RomM.Games
             }
 
             return ArchiveFactory.IsArchive(filePath, out var type);
-        }
-
-        private void ExtractArchive(string gamePath, string installDir)
-        {
-            if (gamePath == null || gamePath.Contains("../") || gamePath.Contains(@"..\"))
-            {
-                throw new ArgumentException("Invalid game path");
-            }
-
-            if (installDir == null || installDir.Contains("../") || installDir.Contains(@"..\"))
-            {
-                throw new ArgumentException("Invalid install directory path");
-            }
-
-            if (_romM.Settings.Use7z && (!string.IsNullOrEmpty(_romM.Settings.PathTo7z) && _romM.Settings.PathTo7z.EndsWith("7z.exe", StringComparison.OrdinalIgnoreCase)))
-            {
-                ProcessStartInfo startInfo = new ProcessStartInfo
-                {
-                    FileName = _romM.Settings.PathTo7z,
-                    Arguments = $"x \"{gamePath}\" -o\"{installDir}\" -y",
-                    UseShellExecute = false,
-                    CreateNoWindow = true
-                };
-
-                using (Process process = Process.Start(startInfo))
-                {
-                    process.WaitForExit();
-                    if(process.ExitCode != 0)
-                    {
-                        _romM.Playnite.Notifications.Add(new NotificationMessage("RomM-Archive-Failed", $"Failed to extract {gamePath}", NotificationType.Error));
-                        throw new Exception($"7z extraction failed for {gamePath} with exit code {process.ExitCode}.");
-                    }
-                }
-            }
-            else
-            {
-                using (var archive = ArchiveFactory.Open(gamePath))
-                {
-                    foreach (var entry in archive.Entries)
-                    {
-                        if (!entry.IsDirectory)
-                        {
-                            entry.WriteToDirectory(installDir, new ExtractionOptions
-                            {
-                                ExtractFullPath = true,
-                                Overwrite = true
-                            });
-                        }
-                    }
-                }
-            }      
-        }
-
-        void ExtractNestedArchives(string directoryPath)
-        {
-            if (directoryPath == null || directoryPath.Contains("../") || directoryPath.Contains(@"..\"))
-            {
-                throw new ArgumentException("Invalid file path");
-            }
-
-            foreach (var file in Directory.GetFiles(directoryPath))
-            {   
-                if (IsFileCompressed(file))
-                {
-                    ExtractArchive(file, directoryPath);
-                    File.Delete(file);
-                }
-            }
         }
     }
 }

--- a/Models/RomM/Rom/RomMRom.cs
+++ b/Models/RomM/Rom/RomMRom.cs
@@ -4,6 +4,49 @@ using Newtonsoft.Json;
 
 namespace RomM.Models.RomM.Rom
 {
+    public class metadatum
+    {
+        [JsonProperty("rom_id")]
+        public int Id { get; set; }
+
+        [JsonProperty("genres")]
+        public List<string> Genres { get; set; }
+
+        [JsonProperty("franchises")]
+        public List<string> Franchises { get; set; }
+
+        [JsonProperty("collections")]
+        public List<string> Collections { get; set; }
+
+        [JsonProperty("companies")]
+        public List<string> Companies { get; set; }
+
+        [JsonProperty("game_modes")]
+        public List<string> Gamemodes { get; set; }
+
+        [JsonProperty("age_ratings")]
+        public List<string> Age_Ratings { get; set; }
+
+        [JsonProperty("first_release_date")]
+        public long? Release_Date { get; set; }
+
+        [JsonProperty("average_rating")]
+        public float? Average_Rating { get; set; }
+
+    }
+
+    public class RomMFile
+    {
+        [JsonProperty("file_name")]
+        public string FileName { get; set; }
+
+        [JsonProperty("file_size_bytes")]
+        public long? FileSize { get; set; }
+
+        [JsonProperty("full_path")]
+        public string FullPath { get; set; }
+    }
+
     public class RomMRom
     {
         [JsonProperty("id")]
@@ -56,6 +99,9 @@ namespace RomM.Models.RomM.Rom
 
         [JsonProperty("first_release_date")]
         public long? FirstReleaseDate { get; set; }
+
+        [JsonProperty("metadatum")]
+        public metadatum Metadatum { get; set; }
 
         [JsonProperty("alternative_names")]
         public List<string> AlternativeNames { get; set; }
@@ -112,7 +158,7 @@ namespace RomM.Models.RomM.Rom
         public bool HasMultipleFiles { get; set; }
 
         [JsonProperty("files")]
-        public List<object> Files { get; set; }
+        public List<RomMFile> Files { get; set; }
 
         [JsonProperty("full_path")]
         public string FullPath { get; set; }

--- a/RomM.cs
+++ b/RomM.cs
@@ -424,7 +424,7 @@ namespace RomM
                             item.HasMultipleFiles = true;
 
                         // Defensive: never allow path segments from server-provided filename & make sure single ROM files have an extention
-                        var fileName = item.HasMultipleFiles ? Path.GetFileName(item.FileName) : item.Files.Where(f => f.FullPath.Count(c => c == '/') <= 3).FirstOrDefault().FileName;
+                        var fileName = item.HasMultipleFiles ? Path.GetFileName(item.FileName) : Path.GetFileName(item.Files.Where(f => f.FullPath.Count(c => c == '/') <= 3).FirstOrDefault().FileName);
                         if (string.IsNullOrWhiteSpace(fileName))
                         {
                             Logger.Warn($"Rom {item.Id} returned empty/invalid filename, skipping.");


### PR DESCRIPTION
### Remerge 7z for new download system
When 7z was merged I did the pull request before the new download system was merged so the code was placed in the wrong area and broken the code

### New Metadata
Used more of the metadata from the RomM server & makes sure that the filename for single file ROMs has an extension & adds fail-safe for when HasSimpleSingleFile , HasNestedSingleFile & HasMultipleFiles are all false

Old metadata:
<img width="1083" height="715" alt="31-01-2026@1358" src="https://github.com/user-attachments/assets/c611ffdb-1bca-419c-938c-577b6d231a06" />

New metadata:
<img width="1083" height="717" alt="31-01-2026@1400" src="https://github.com/user-attachments/assets/b6624b42-78bd-44a7-b0dd-6718fdad14d9" />

### Build
Here is a debug build with all the additions that have been added, I have tested it on my Playnite and with a fresh install in sandbox and everything seems to work, the only issue with it is that the sharpcompress.dll isn't packed with the extension but this might be because I didn't pack it right
[RomM_9700aa21-447d-41b4-a989-acd38f407d9f_0_4_1.zip](https://github.com/user-attachments/files/25005106/RomM_9700aa21-447d-41b4-a989-acd38f407d9f_0_4_1.zip)
