### PR TITLE
Filtering out sibling ROMs from showing during scans

### DIFF
--- a/Models/RomM/Rom/RomMRom.cs
+++ b/Models/RomM/Rom/RomMRom.cs
@@ -160,6 +160,9 @@ namespace RomM.Models.RomM.Rom
         [JsonProperty("files")]
         public List<RomMFile> Files { get; set; }
 
+        [JsonProperty("siblings")]
+        public List<RomMSibling> Siblings { get; set; }
+
         [JsonProperty("full_path")]
         public string FullPath { get; set; }
 
@@ -174,5 +177,17 @@ namespace RomM.Models.RomM.Rom
 
         [JsonProperty("sort_comparator")]
         public string SortComparator { get; set; }
+    }
+
+    public class RomMSibling
+    {
+        [JsonProperty("id")]
+        public int Id { get; set; }
+
+        [JsonProperty("file_name")]
+        public string FileName { get; set; }
+
+        [JsonProperty("is_main_sibling")]
+        public bool IsMainSibling { get; set; }
     }
 }


### PR DESCRIPTION
Hopefully this will be a start at working towards #91.


- Updated Models/RomM/Rom/RomMRom.cs to include grabbing the siblings of ROMs and a new class of RomMSibling
- Updated RomM.cs to utilize the new method for ROM siblings to allow the skipping of ROM siblings when necessary.

	modified:   Models/RomM/Rom/RomMRom.cs
	modified:   RomM.cs