### PR TITLE
Add API token authentication

### DIFF
--- a/RomM.cs
+++ b/RomM.cs
@@ -39,10 +39,22 @@ namespace RomM
             httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
         }
 
-        public static void ConfigureBasicAuth(string username, string password)
+        public static void ConfigureAuth(SettingsViewModel settings)
         {
-            var base64Credentials = Convert.ToBase64String(Encoding.ASCII.GetBytes($"{username}:{password}"));
-            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", base64Credentials);
+            httpClient.DefaultRequestHeaders.Authorization = BuildAuthHeader(settings);
+        }
+
+        public static AuthenticationHeaderValue BuildAuthHeader(SettingsViewModel settings)
+        {
+            var token = settings.RomMApiToken?.Trim();
+            if (SettingsViewModel.IsValidApiToken(token))
+            {
+                return new AuthenticationHeaderValue("Bearer", token);
+            }
+
+            var creds = Convert.ToBase64String(
+                Encoding.ASCII.GetBytes($"{settings.RomMUsername}:{settings.RomMPassword}"));
+            return new AuthenticationHeaderValue("Basic", creds);
         }
 
         public static HttpClient Instance => httpClient;
@@ -259,7 +271,7 @@ namespace RomM
             base.OnApplicationStarted(args);
 
             Settings = new SettingsViewModel(this, this);
-            HttpClientSingleton.ConfigureBasicAuth(Settings.RomMUsername, Settings.RomMPassword);
+            HttpClientSingleton.ConfigureAuth(Settings);
             Playnite.UriHandler.RegisterSource("romm", HandleRommUri);
 
             // Portable path fix: expand "{PlayniteDir}" to absolute paths in DB on startup
@@ -404,11 +416,15 @@ namespace RomM
                 return new List<GameMetadata>();
             }
 
-            if (string.IsNullOrEmpty(Settings.RomMHost) ||
-                string.IsNullOrEmpty(Settings.RomMUsername) ||
-                string.IsNullOrEmpty(Settings.RomMPassword))
+            if (string.IsNullOrEmpty(Settings.RomMHost))
             {
-                Logger.Warn("RomM host, username or password is not set.");
+                Logger.Warn("RomM host is not set.");
+                return new List<GameMetadata>();
+            }
+
+            if (!Settings.HasAnyAuth)
+            {
+                Logger.Warn("RomM API token (rmm_ + 64 hex chars) or username/password must be set.");
                 return new List<GameMetadata>();
             }
 

--- a/RomM.cs
+++ b/RomM.cs
@@ -52,9 +52,14 @@ namespace RomM
                 return new AuthenticationHeaderValue("Bearer", token);
             }
 
-            var creds = Convert.ToBase64String(
-                Encoding.ASCII.GetBytes($"{settings.RomMUsername}:{settings.RomMPassword}"));
-            return new AuthenticationHeaderValue("Basic", creds);
+            if (!string.IsNullOrEmpty(settings.RomMUsername) && !string.IsNullOrEmpty(settings.RomMPassword))
+            {
+                var creds = Convert.ToBase64String(
+                    Encoding.ASCII.GetBytes($"{settings.RomMUsername}:{settings.RomMPassword}"));
+                return new AuthenticationHeaderValue("Basic", creds);
+            }
+
+            return null;
         }
 
         public static HttpClient Instance => httpClient;

--- a/Settings/Settings.cs
+++ b/Settings/Settings.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace RomM.Settings
 {
@@ -23,12 +24,26 @@ namespace RomM.Settings
 
         public static SettingsViewModel Instance { get; private set; }
 
+        // RomM client API tokens are "rmm_" + 64 lowercase hex chars (secrets.token_hex(32) on the server).
+        private static readonly Regex ApiTokenPattern = new Regex(@"^rmm_[0-9a-f]{64}$", RegexOptions.Compiled);
+
+        public static bool IsValidApiToken(string token)
+        {
+            return !string.IsNullOrEmpty(token) && ApiTokenPattern.IsMatch(token);
+        }
+
+        [JsonIgnore]
+        public bool HasAnyAuth =>
+            IsValidApiToken(RomMApiToken?.Trim()) ||
+            (!string.IsNullOrEmpty(RomMUsername) && !string.IsNullOrEmpty(RomMPassword));
+
         public bool ScanGamesInFullScreen { get; set; } = false;
         public bool NotifyOnInstallComplete { get; set; } = false;
         public bool KeepRomMSynced { get; set; } = false;
         public string RomMHost { get; set; } = "";
         public string RomMUsername { get; set; } = "";
         public string RomMPassword { get; set; } = "";
+        public string RomMApiToken { get; set; } = "";
         public ObservableCollection<EmulatorMapping> Mappings { get; set; }
 
         public bool Use7z { get; set; } = false;
@@ -57,6 +72,7 @@ namespace RomM.Settings
                 RomMHost = savedSettings.RomMHost;
                 RomMUsername = savedSettings.RomMUsername;
                 RomMPassword = savedSettings.RomMPassword;
+                RomMApiToken = savedSettings.RomMApiToken ?? "";
                 Mappings = savedSettings.Mappings;
                 KeepRomMSynced = savedSettings.KeepRomMSynced;
                 Use7z = savedSettings.Use7z;
@@ -100,7 +116,7 @@ namespace RomM.Settings
             // Code executed when user decides to confirm changes made since BeginEdit was called.
             // This method should save settings made to Option1 and Option2.
             SavePluginSettings(this);
-            HttpClientSingleton.ConfigureBasicAuth(this.RomMUsername, this.RomMPassword);
+            HttpClientSingleton.ConfigureAuth(this);
         }
 
         private void SavePluginSettings<SettingsViewModel>(SettingsViewModel settings)
@@ -119,6 +135,11 @@ namespace RomM.Settings
         public bool VerifySettings(out List<string> errors)
         {
             var mappingErrors = new List<string>();
+
+            if (!string.IsNullOrWhiteSpace(RomMApiToken) && !IsValidApiToken(RomMApiToken.Trim()))
+            {
+                mappingErrors.Add("API Token must start with 'rmm_' followed by 64 lowercase hex characters.");
+            }
 
             Mappings.Where(m => m.Enabled)?.ForEach(m =>
             {

--- a/Settings/Settings.cs
+++ b/Settings/Settings.cs
@@ -43,7 +43,21 @@ namespace RomM.Settings
         public string RomMHost { get; set; } = "";
         public string RomMUsername { get; set; } = "";
         public string RomMPassword { get; set; } = "";
-        public string RomMApiToken { get; set; } = "";
+        private string _romMApiToken = "";
+        public string RomMApiToken
+        {
+            get => _romMApiToken;
+            set
+            {
+                if (_romMApiToken == value) return;
+                _romMApiToken = value;
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(HasValidApiToken));
+            }
+        }
+
+        [JsonIgnore]
+        public bool HasValidApiToken => IsValidApiToken(RomMApiToken?.Trim());
         public ObservableCollection<EmulatorMapping> Mappings { get; set; }
 
         public bool Use7z { get; set; } = false;

--- a/Settings/SettingsView.xaml
+++ b/Settings/SettingsView.xaml
@@ -4,6 +4,24 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008" x:Class="RomM.Settings.SettingsView"
     xmlns:local="clr-namespace:RomM.Settings"
     xmlns:sys="clr-namespace:System;assembly=mscorlib" mc:Ignorable="d" d:DesignHeight="400" d:DesignWidth="600" Padding="2,0,2,4">
+    <UserControl.Resources>
+        <Style x:Key="DimmedWhenTokenSet" TargetType="Label" BasedOn="{StaticResource {x:Type Label}}">
+            <Setter Property="Opacity" Value="0.5"/>
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding ElementName=RomMApiToken, Path=Text.Length}" Value="0">
+                    <Setter Property="Opacity" Value="1"/>
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
+        <Style x:Key="DisabledWhenTokenSet" TargetType="TextBox" BasedOn="{StaticResource {x:Type TextBox}}">
+            <Setter Property="IsEnabled" Value="False"/>
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding ElementName=RomMApiToken, Path=Text.Length}" Value="0">
+                    <Setter Property="IsEnabled" Value="True"/>
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
+    </UserControl.Resources>
     <DockPanel Margin="20">
         <ScrollViewer DockPanel.Dock="Top">
             <StackPanel x:Name="EmulatorSettingsPanel">
@@ -12,9 +30,12 @@
                 <Grid Margin="0,0,0,10">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="200"/>
+                        <ColumnDefinition Width="300"/>
+                        <ColumnDefinition Width="*"/>
                     </Grid.ColumnDefinitions>
                     <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
@@ -24,13 +45,46 @@
                     <Label Content="RomM Host" Grid.Row="0" Grid.Column="0" Margin="0,0,5,5"/>
                     <TextBox x:Name="RomMHost" Grid.Row="0" Grid.Column="1" Margin="3,2,0,2" Text="{Binding RomMHost, Mode=TwoWay}" />
 
+                    <!-- API Token Label and TextBox -->
+                    <Label Content="API Token" Grid.Row="1" Grid.Column="0" Margin="0,0,5,5"/>
+                    <TextBox x:Name="RomMApiToken" Grid.Row="1" Grid.Column="1" Margin="3,2,0,2" Text="{Binding RomMApiToken, Mode=TwoWay}" />
+                    <TextBlock Grid.Row="1" Grid.Column="2" Margin="8,0,0,0" VerticalAlignment="Center"
+                               MaxWidth="260" TextWrapping="Wrap"
+                               Foreground="{DynamicResource TextBrush}"
+                               FontWeight="Normal" Opacity="0.5"
+                               Text="Enabling the API token disables credential-based auth.">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Visibility" Value="Visible"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding ElementName=RomMApiToken, Path=Text.Length}" Value="0">
+                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+
                     <!-- Username Label and TextBox -->
-                    <Label Content="Username" Grid.Row="1" Grid.Column="0" Margin="0,0,5,5"/>
-                    <TextBox x:Name="RomMUsername" Grid.Row="1" Grid.Column="1" Margin="3,2,0,2" Text="{Binding RomMUsername, Mode=TwoWay}" />
+                    <Label Grid.Row="2" Grid.Column="0" Margin="0,0,5,5" Content="Username"
+                           Style="{StaticResource DimmedWhenTokenSet}"/>
+                    <TextBox x:Name="RomMUsername" Grid.Row="2" Grid.Column="1" Margin="3,2,0,2"
+                             Style="{StaticResource DisabledWhenTokenSet}"
+                             Text="{Binding RomMUsername, Mode=TwoWay}"
+                             ToolTip="Disabled while an API token is set."/>
 
                     <!-- Password Label and TextBox -->
-                    <Label Content="Password" Grid.Row="2" Grid.Column="0" Margin="0,5,5,0"/>
-                    <TextBox x:Name="RomMPassword" Grid.Row="2" Grid.Column="1" Margin="3,2,0,2" Text="{Binding RomMPassword, Mode=TwoWay}"/>
+                    <Label Grid.Row="3" Grid.Column="0" Margin="0,5,5,0" Content="Password"
+                           Style="{StaticResource DimmedWhenTokenSet}"/>
+                    <TextBox x:Name="RomMPassword" Grid.Row="3" Grid.Column="1" Margin="3,2,0,2"
+                             Style="{StaticResource DisabledWhenTokenSet}"
+                             Text="{Binding RomMPassword, Mode=TwoWay}"
+                             ToolTip="Disabled while an API token is set."/>
+
+                    <!-- Test Connection Button -->
+                    <Button x:Name="TestConnectionButton" Grid.Row="4" Grid.Column="1" Margin="3,8,0,0"
+                            HorizontalAlignment="Left" Padding="12,4" Click="Click_TestConnection"
+                            Content="Test connection"/>
                 </Grid>
                 <Label Content="Emulator path mappings" FontWeight="Bold" />
                 <TextBlock HorizontalAlignment="Right" Margin="0,-16,0,0">

--- a/Settings/SettingsView.xaml
+++ b/Settings/SettingsView.xaml
@@ -6,18 +6,18 @@
     xmlns:sys="clr-namespace:System;assembly=mscorlib" mc:Ignorable="d" d:DesignHeight="400" d:DesignWidth="600" Padding="2,0,2,4">
     <UserControl.Resources>
         <Style x:Key="DimmedWhenTokenSet" TargetType="Label" BasedOn="{StaticResource {x:Type Label}}">
-            <Setter Property="Opacity" Value="0.5"/>
+            <Setter Property="Opacity" Value="1"/>
             <Style.Triggers>
-                <DataTrigger Binding="{Binding ElementName=RomMApiToken, Path=Text.Length}" Value="0">
-                    <Setter Property="Opacity" Value="1"/>
+                <DataTrigger Binding="{Binding HasValidApiToken}" Value="True">
+                    <Setter Property="Opacity" Value="0.5"/>
                 </DataTrigger>
             </Style.Triggers>
         </Style>
         <Style x:Key="DisabledWhenTokenSet" TargetType="TextBox" BasedOn="{StaticResource {x:Type TextBox}}">
-            <Setter Property="IsEnabled" Value="False"/>
+            <Setter Property="IsEnabled" Value="True"/>
             <Style.Triggers>
-                <DataTrigger Binding="{Binding ElementName=RomMApiToken, Path=Text.Length}" Value="0">
-                    <Setter Property="IsEnabled" Value="True"/>
+                <DataTrigger Binding="{Binding HasValidApiToken}" Value="True">
+                    <Setter Property="IsEnabled" Value="False"/>
                 </DataTrigger>
             </Style.Triggers>
         </Style>
@@ -52,18 +52,7 @@
                                MaxWidth="260" TextWrapping="Wrap"
                                Foreground="{DynamicResource TextBrush}"
                                FontWeight="Normal" Opacity="0.5"
-                               Text="Enabling the API token disables credential-based auth.">
-                        <TextBlock.Style>
-                            <Style TargetType="TextBlock">
-                                <Setter Property="Visibility" Value="Visible"/>
-                                <Style.Triggers>
-                                    <DataTrigger Binding="{Binding ElementName=RomMApiToken, Path=Text.Length}" Value="0">
-                                        <Setter Property="Visibility" Value="Collapsed"/>
-                                    </DataTrigger>
-                                </Style.Triggers>
-                            </Style>
-                        </TextBlock.Style>
-                    </TextBlock>
+                               Text="A valid API token takes precedence over credential auth." />
 
                     <!-- Username Label and TextBox -->
                     <Label Grid.Row="2" Grid.Column="0" Margin="0,0,5,5" Content="Username"

--- a/Settings/SettingsView.xaml.cs
+++ b/Settings/SettingsView.xaml.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
 using System.Windows;
 using System.Windows.Controls;
 
@@ -39,6 +42,73 @@ namespace RomM.Settings
             }
 
             mapping.DestinationPath = path;
+        }
+
+        private async void Click_TestConnection(object sender, RoutedEventArgs e)
+        {
+            var settings = SettingsViewModel.Instance;
+            var dialogs = settings.PlayniteAPI.Dialogs;
+
+            var host = settings.RomMHost?.Trim().TrimEnd('/');
+            if (string.IsNullOrWhiteSpace(host))
+            {
+                dialogs.ShowMessage("RomM Host is empty.", "RomM");
+                return;
+            }
+
+            if (!settings.HasAnyAuth)
+            {
+                dialogs.ShowMessage("Provide either a valid API Token or username and password.", "RomM");
+                return;
+            }
+
+            var button = (Button)sender;
+            var originalContent = button.Content;
+
+            try
+            {
+                button.IsEnabled = false;
+                button.Content = "Testing...";
+
+                using (var req = new HttpRequestMessage(HttpMethod.Get, $"{host}/api/users/me"))
+                {
+                    req.Headers.Authorization = HttpClientSingleton.BuildAuthHeader(settings);
+                    using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10)))
+                    {
+                        var resp = await HttpClientSingleton.Instance.SendAsync(req, cts.Token);
+
+                        if (resp.IsSuccessStatusCode)
+                        {
+                            dialogs.ShowMessage($"Connection successful ({(int)resp.StatusCode}).", "RomM");
+                        }
+                        else if (resp.StatusCode == HttpStatusCode.Unauthorized || resp.StatusCode == HttpStatusCode.Forbidden)
+                        {
+                            dialogs.ShowMessage($"Authentication rejected (HTTP {(int)resp.StatusCode}). Check your API token or username/password.", "RomM");
+                        }
+                        else
+                        {
+                            dialogs.ShowMessage($"Connection failed: HTTP {(int)resp.StatusCode} {resp.ReasonPhrase}", "RomM");
+                        }
+                    }
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                dialogs.ShowMessage("Connection timed out after 10 seconds.", "RomM");
+            }
+            catch (HttpRequestException ex)
+            {
+                dialogs.ShowMessage($"Connection failed: {ex.Message}", "RomM");
+            }
+            catch (Exception ex)
+            {
+                dialogs.ShowMessage($"Unexpected error: {ex.Message}", "RomM");
+            }
+            finally
+            {
+                button.IsEnabled = true;
+                button.Content = originalContent;
+            }
         }
 
         private void Click_Browse7zDestination(object sender, RoutedEventArgs e)

--- a/Settings/SettingsView.xaml.cs
+++ b/Settings/SettingsView.xaml.cs
@@ -74,9 +74,8 @@ namespace RomM.Settings
                 {
                     req.Headers.Authorization = HttpClientSingleton.BuildAuthHeader(settings);
                     using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10)))
+                    using (var resp = await HttpClientSingleton.Instance.SendAsync(req, cts.Token))
                     {
-                        var resp = await HttpClientSingleton.Instance.SendAsync(req, cts.Token);
-
                         if (resp.IsSuccessStatusCode)
                         {
                             dialogs.ShowMessage($"Connection successful ({(int)resp.StatusCode}).", "RomM");


### PR DESCRIPTION
Closes #32                                                                                                                                                                     

Adds API token support so RomM instances sitting behind an SSO (Authelia, Authentik, etc.) can be reached from the plugin. 

<img width="1340" height="1044" alt="image" src="https://github.com/user-attachments/assets/7d4ff6fc-4972-4e1b-baad-9c6ab3c594fc" />

This was written with Claude Code. 