### PR TITLE
Backfill Version field for legacy RomM games on refresh

### DIFF
--- a/RomM.cs
+++ b/RomM.cs
@@ -689,20 +689,25 @@ namespace RomM
                         var game = Playnite.Database.Games.FirstOrDefault(g => g.GameId == gameId);
                         if (game != null)
                         {
+                            var expectedVersion = $"RomM:{item.Id}";
+                            var needsVersionBackfill = game.Version != expectedVersion;
+
                             // If it is already installed, we sync over metadata like favorite and status
                             if (Settings.KeepRomMSynced == true)
                             {
                                 game.Favorite = favorites.Exists(f => f == item.Id);
-                                
+
                                 if (statusId != Guid.Empty)
                                 {
                                     game.CompletionStatusId = statusId;
                                 }
-
+                            }
+                            
+                            if (Settings.KeepRomMSynced == true || needsVersionBackfill)
+                            {
                                 // Using the Version-Field for storing the ID instead of "RomMGameInfo"
                                 // Could be useful in the future: https://github.com/JosefNemec/Playnite/issues/801
-                                game.Version = $"RomM:{item.Id}";
-
+                                game.Version = expectedVersion;
                                 ignoredGameIds.TryAdd(game.Id, 0);
                                 Playnite.Database.Games.Update(game);
                             }


### PR DESCRIPTION
## Summary
- Library refresh now writes `Game.Version = "RomM:{id}"` for existing games even when `KeepRomMSynced` is off, as long as the value is missing or stale.
- Fixes the `Couldn't find RomMId for <game>` warning spam for users whose games were imported before the RomMId moved into the `Version` field (commit 6205bc3), and unblocks the install/uninstall/game-menu code paths that read the ID back from `Version`.
- `KeepRomMSynced == true` still gets the full Favorite + CompletionStatus + Version write; sync-off users now get the Version-only backfill.

## Test plan
- [ ] Start Playnite with a RomM library imported before 6205bc3 and `KeepRomMSynced` disabled; trigger a library refresh and confirm the warnings stop appearing for previously-warning games.
- [ ] Repeat with `KeepRomMSynced` enabled and confirm Favorite/CompletionStatus still sync as before.
- [ ] Trigger install on a previously-warning game and confirm the install flow proceeds without the "Couldn't find RomMId" notification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)