### PR TITLE
test: add unit test framework (RomM.Tests) and CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,61 @@
+name: Tests
+
+# Runs the RomM.Tests unit suite, and (on direct pushes) also compiles the plugin so the
+# pure-logic seams stay in sync. The test project links the plugin's pure-logic source files
+# directly (no WPF/XAML project reference), so it builds/runs under `dotnet test` rather than the
+# full msbuild flow used to package the extension.
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: test-${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Compile the plugin itself on pushes (PRs are already covered by pr-build.yml). Mirrors that
+  # workflow so seam refactors that touch the WPF/plugin project are verified here too.
+  build-plugin:
+    if: github.event_name == 'push'
+    runs-on: windows-2025-vs2026
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v2
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.x
+
+      - name: Restore dependencies
+        run: |
+          dotnet restore
+          dotnet add package Microsoft.Net.Sdk.Compilers.Toolset --version 9.0.300
+
+      - name: Build with MSBuild
+        run: |
+          msbuild RomM.csproj /p:Configuration=Release /p:Platform="AnyCPU" /p:RestorePackages=false
+
+  test:
+    runs-on: windows-2025-vs2026
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.x
+
+      - name: Restore
+        run: dotnet restore RomM.Tests/RomM.Tests.csproj
+
+      - name: Test
+        run: dotnet test RomM.Tests/RomM.Tests.csproj --configuration Release --no-restore --logger "console;verbosity=normal"

--- a/Games/RomMCompletionStatus.cs
+++ b/Games/RomMCompletionStatus.cs
@@ -1,0 +1,26 @@
+using RomM.Models.RomM.Rom;
+
+namespace RomM.Games
+{
+    // Maps a server-side rom_user to the Playnite completion-status name. Pure so the precedence and
+    // fallback rules are unit-testable without the Playnite database (the name -> status-id lookup
+    // stays in the importer).
+    internal static class RomMCompletionStatus
+    {
+        // "now playing" and "backlogged" take precedence over the reported status; an unknown/missing
+        // status falls back to "Not Played" rather than throwing.
+        public static string ResolvePlayniteStatusName(RomMRomUser user)
+        {
+            if (user.Backlogged || user.NowPlaying)
+                return user.NowPlaying
+                    ? RomMRomUser.CompletionStatusMap["now_playing"]
+                    : RomMRomUser.CompletionStatusMap["backlogged"];
+
+            var romMStatus = user.Status ?? "not_played";
+            if (!RomMRomUser.CompletionStatusMap.TryGetValue(romMStatus, out var name))
+                name = RomMRomUser.CompletionStatusMap["not_played"];
+
+            return name;
+        }
+    }
+}

--- a/Games/RomMGameInfo.Plugin.cs
+++ b/Games/RomMGameInfo.Plugin.cs
@@ -1,0 +1,56 @@
+using Playnite.SDK.Models;
+using Playnite.SDK.Plugins;
+using RomM.Settings;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using ProtoBuf;
+using RomM.Models.RomM.Rom;
+
+namespace RomM.Games
+{
+    // Plugin-coupled half of RomMGameInfo: resolving the emulator mapping and constructing the
+    // install/uninstall controllers. Kept out of RomMGameInfo.cs so the serialization half stays
+    // unit-testable without the Playnite/plugin runtime.
+    internal partial class RomMGameInfo
+    {
+        public EmulatorMapping Mapping
+        {
+            get
+            {
+                return Settings.SettingsViewModel.Instance.Mappings.FirstOrDefault(m => m.MappingId == MappingId);
+            }
+        }
+
+        public InstallController GetInstallController(Game game, RomM romm, GameInstallInfo GameData) => new RomMInstallController(game, romm, GameData);
+
+        public UninstallController GetUninstallController(Game game, RomM romm) => new RomMUninstallController(game, romm);
+
+        protected IEnumerable<string> GetDescriptionLines()
+        {
+            yield return $"{nameof(DownloadUrl)} : {DownloadUrl}";
+        }
+
+        public string ToDescriptiveString(Game g)
+        {
+            var sb = new System.Text.StringBuilder();
+            sb.AppendLine($"Game: {g.Name}");
+            sb.AppendLine($"Type: {GetType()}");
+            sb.AppendLine($"{nameof(MappingId)}: {MappingId}");
+
+            GetDescriptionLines().ForEach(l => sb.AppendLine(l));
+
+            var mapping = Mapping;
+            if (mapping != null)
+            {
+                sb.AppendLine();
+                sb.AppendLine("Mapping Info:");
+                mapping.GetDescriptionLines().ForEach(l => sb.AppendLine($"    {l}"));
+            }
+
+            return sb.ToString();
+        }
+    }
+}

--- a/Games/RomMGameInfo.cs
+++ b/Games/RomMGameInfo.cs
@@ -1,18 +1,17 @@
-﻿using Playnite.SDK.Models;
-using Playnite.SDK.Plugins;
-using RomM.Settings;
+using Playnite.SDK.Models;
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using ProtoBuf;
-using RomM.Models.RomM.Rom;
 
 namespace RomM.Games
 {
+    // Pure serialization half of RomMGameInfo: the protobuf contract behind the legacy "!0..." game
+    // ids, plus the (de)serialization round-trip. Split from the plugin-coupled half (Mapping, install
+    // controllers) so it can be unit-tested without the Playnite/plugin runtime. The protobuf member
+    // numbers MUST stay stable — existing installs encode their game ids with them.
     [ProtoContract]
-    internal class RomMGameInfo
+    internal partial class RomMGameInfo
     {
         [ProtoMember(1)]
         public Guid MappingId { get; set; }
@@ -25,14 +24,6 @@ namespace RomM.Games
 
         [ProtoMember(4)]
         public bool HasMultipleFiles { get; set; }
-
-        public EmulatorMapping Mapping
-        {
-            get
-            {
-                return Settings.SettingsViewModel.Instance.Mappings.FirstOrDefault(m => m.MappingId == MappingId);
-            }
-        }
 
         public string AsGameId()
         {
@@ -66,35 +57,6 @@ namespace RomM.Games
             {
                 return Serializer.Deserialize<T>(ms);
             }
-        }
-
-        public InstallController GetInstallController(Game game, RomM romm, GameInstallInfo GameData) => new RomMInstallController(game, romm, GameData);
-
-        public UninstallController GetUninstallController(Game game, RomM romm) => new RomMUninstallController(game, romm);
-
-        protected IEnumerable<string> GetDescriptionLines()
-        {
-            yield return $"{nameof(DownloadUrl)} : {DownloadUrl}";
-        }
-
-        public string ToDescriptiveString(Game g)
-        {
-            var sb = new System.Text.StringBuilder();
-            sb.AppendLine($"Game: {g.Name}");
-            sb.AppendLine($"Type: {GetType()}");
-            sb.AppendLine($"{nameof(MappingId)}: {MappingId}");
-
-            GetDescriptionLines().ForEach(l => sb.AppendLine(l));
-
-            var mapping = Mapping;
-            if (mapping != null)
-            {
-                sb.AppendLine();
-                sb.AppendLine("Mapping Info:");
-                mapping.GetDescriptionLines().ForEach(l => sb.AppendLine($"    {l}"));
-            }
-
-            return sb.ToString();
         }
     }
 }

--- a/Games/RomMHash.cs
+++ b/Games/RomMHash.cs
@@ -1,0 +1,25 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace RomM.Games
+{
+    // Some newer platforms don't get a server-side hash, so we synthesise a stable one from the rom id
+    // plus its base file name. Pure and deterministic so the game still gets a stable "romMId:sha1" id.
+    internal static class RomMHash
+    {
+        public static string FallbackSha1Hex(int romId, string fileNameNoExt)
+        {
+            var toHash = $"{romId}{fileNameNoExt}";
+
+            using (var sha1 = new SHA1Managed())
+            {
+                var hash = sha1.ComputeHash(Encoding.UTF8.GetBytes(toHash));
+                var sb = new StringBuilder(hash.Length * 2);
+                foreach (byte b in hash)
+                    sb.Append(b.ToString("x2"));
+
+                return sb.ToString();
+            }
+        }
+    }
+}

--- a/Games/RomMImport.cs
+++ b/Games/RomMImport.cs
@@ -8,8 +8,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Security.Cryptography;
-using System.Text;
 
 namespace RomM.Games
 {
@@ -65,53 +63,9 @@ namespace RomM.Games
             _favourites = favourites;
         }
 
-        private RomMFile DetermineFile(RomMRom ROM)
-        {
-            if(ROM.Files.Count == 0)
-                return null;
-
-            if(ROM.Files.Count > 1)
-            {
-                // Return the file that sits highest in the folder tree (fewest path separators).
-                return ROM.Files.OrderBy(f => (f.FullPath ?? string.Empty).Count(c => c == '/')).FirstOrDefault();
-            }
-
-            return ROM.Files.FirstOrDefault();
-        }
-
-        // Builds the install descriptor for a single ROM (base or sibling). Returns null when a
-        // single-file ROM has no resolvable file. Single files use the 4.9 /files/content endpoint,
-        // multi-file ROMs download the whole rom as an archive.
+        // Builds the per-ROM download descriptor via the shared factory (see RomMRevisionFactory).
         private RomMRevision BuildRevision(RomMRom rom)
-        {
-            var revision = new RomMRevision
-            {
-                Id = rom.Id,
-                HasMultipleFiles = rom.HasMultipleFiles,
-                IsSelected = false
-            };
-
-            if (!rom.HasMultipleFiles)
-            {
-                var romfile = DetermineFile(rom);
-                if (romfile == null)
-                    return null;
-
-                revision.FileName = romfile.FileName;
-                // The 4.9 single-file endpoint needs the file id; fall back to the rom-level endpoint
-                // when the payload doesn't include one so we never emit "api/roms//files/content/...".
-                revision.DownloadURL = romfile.Id.HasValue
-                    ? _plugin.CombineUrl(_plugin.Settings.RomMHost, $"api/roms/{romfile.Id}/files/content/{romfile.FileName}")
-                    : _plugin.CombineUrl(_plugin.Settings.RomMHost, $"api/roms/{rom.Id}/content/{romfile.FileName}");
-            }
-            else
-            {
-                revision.FileName = rom.FileName;
-                revision.DownloadURL = _plugin.CombineUrl(_plugin.Settings.RomMHost, $"api/roms/{rom.Id}/content/{rom.FileName}");
-            }
-
-            return revision;
-        }
+            => RomMRevisionFactory.Build(rom, _plugin.Settings.RomMHost);
 
         // Main library import functions
         public List<Game> ProcessData()
@@ -133,23 +87,10 @@ namespace RomM.Games
                     // never has to null-check (mirrors the hardening done in #107).
                     ROM.Normalize();
 
-                    // Some newer platforms don't get a hash value so we will compromise with this
+                    // Some newer platforms don't get a hash value so we synthesise a stable one.
                     if (string.IsNullOrEmpty(ROM.SHA1))
                     {
-                        var tohash = $"{ROM.Id}{ROM.FileNameNoExt}";
-
-                        using (SHA1Managed sha1 = new SHA1Managed())
-                        {
-                            var hash = sha1.ComputeHash(Encoding.UTF8.GetBytes(tohash));
-                            var sb = new StringBuilder(hash.Length * 2);
-
-                            foreach (byte b in hash)
-                            {
-                                sb.Append(b.ToString("x2"));
-                            }
-
-                            ROM.SHA1 = sb.ToString();
-                        }
+                        ROM.SHA1 = RomMHash.FallbackSha1Hex(ROM.Id, ROM.FileNameNoExt);
                     }
 
                     // Skip game import if the ROM is part of the exclusion list
@@ -250,8 +191,8 @@ namespace RomM.Games
             // don't match the installed file, breaking IsInstalled detection and the play path.
             var baseRevision = BuildRevision(ROM);
             var fileName = !string.IsNullOrEmpty(baseRevision?.FileName) ? baseRevision.FileName : ROM.Name;
-            var gameInstallDir = Path.Combine(rootInstallDir, Path.GetFileNameWithoutExtension(fileName));
-            var pathToGame = Path.Combine(gameInstallDir, fileName);
+            var gameInstallDir = RomMInstallPaths.InstallDir(rootInstallDir, fileName);
+            var pathToGame = RomMInstallPaths.GamePath(rootInstallDir, fileName);
 
             var status = _plugin.Playnite.Database.CompletionStatuses.Get(StatusID);
             var completionStatusProperty = status != null ? new MetadataNameProperty(status.Name) : null;
@@ -404,23 +345,7 @@ namespace RomM.Games
         }
 
         private MainSibling CheckForMainSibling(RomMRom ROM)
-        {
-            //Check to see if ROM is the main sibling
-            if (ROM.RomUser.IsMainSibling)
-                return MainSibling.Current;
-
-            //Find if there is a main sibling
-            foreach (var sibling in ROM.Siblings)
-            {
-                // The sibling may live on a different page and not be present in this batch.
-                if (_romById.TryGetValue(sibling.Id, out var siblingROM) && siblingROM.RomUser != null && siblingROM.RomUser.IsMainSibling)
-                {
-                    return MainSibling.Other;
-                }
-            }
-
-            return MainSibling.None;
-        }
+            => RomMSiblings.ClassifyMain(ROM, _romById);
 
         private void SaveGameData(RomMRom ROM)
         {
@@ -490,22 +415,7 @@ namespace RomM.Games
 
         private Guid DetermineCompletionStatus(RomMRom ROM)
         {
-            string completionStatus;
-            // Determine status in Playnite. Backlogged and "now playing" take precedent over the status options
-            if (ROM.RomUser.Backlogged || ROM.RomUser.NowPlaying)
-            {
-                completionStatus = ROM.RomUser.NowPlaying ? RomMRomUser.CompletionStatusMap["now_playing"] : RomMRomUser.CompletionStatusMap["backlogged"];
-            }
-            else
-            {
-                // RomM may report a status value we don't map; fall back instead of throwing KeyNotFoundException.
-                var romMStatus = ROM.RomUser.Status ?? "not_played";
-                if (!RomMRomUser.CompletionStatusMap.TryGetValue(romMStatus, out completionStatus))
-                {
-                    completionStatus = RomMRomUser.CompletionStatusMap["not_played"];
-                }
-            }
-
+            string completionStatus = RomMCompletionStatus.ResolvePlayniteStatusName(ROM.RomUser);
             _completionStatusMap.TryGetValue(completionStatus, out var statusId);
             return statusId;
         }

--- a/Games/RomMImportController.cs
+++ b/Games/RomMImportController.cs
@@ -30,21 +30,12 @@ namespace RomM.Games
 
         public List<Game> Import(LibraryImportGamesArgs args)
         {
-            // Only block servers we can positively identify as older than 4.9. Dev builds report a
-            // non-numeric version (e.g. "development"), which we assume is recent enough to import.
-            // Pre-release suffixes (e.g. "4.9.0-beta") are stripped before parsing.
-            string rawVersion = (_plugin.Settings.ServerVersion ?? string.Empty).Split('-', '+')[0];
-            if (Version.TryParse(rawVersion, out Version versionParsed))
+            // Only block servers we can positively identify as older than 4.9. Dev/non-numeric
+            // versions and pre-release suffixes are treated as compatible (see RomMServerVersion).
+            if (!RomMServerVersion.SupportsImport(_plugin.Settings.ServerVersion))
             {
-                if (versionParsed.CompareTo(new Version(4, 9)) < 0)
-                {
-                    _plugin.Playnite.Notifications.Add(_plugin.Id.ToString(), "RomM Server 4.9 or later required to import ROMs!", NotificationType.Error);
-                    return new List<Game>();
-                }
-            }
-            else
-            {
-                Logger.Warn($"[Import Controller] Could not parse RomM server version \"{_plugin.Settings.ServerVersion}\"; assuming it's compatible (>= 4.9).");
+                _plugin.Playnite.Notifications.Add(_plugin.Id.ToString(), "RomM Server 4.9 or later required to import ROMs!", NotificationType.Error);
+                return new List<Game>();
             }
 
             IList<RomMPlatform> apiPlatforms = FetchPlatforms();
@@ -119,31 +110,8 @@ namespace RomM.Games
 
         private string BuildROMUrl()
         {
-            string url = _plugin.CombineUrl(_plugin.Settings.RomMHost, "api/roms");
-
-            if (_plugin.Settings.SkipMissingFiles)
-            {
-                url += "?missing=false&";
-            }
-
-            // Exclude genres from import
-            string excludeGenresString = (_plugin.Settings.ExcludeGenres ?? string.Empty).Trim(' ');
-            excludeGenresString = excludeGenresString.Trim(';');
-            List<string> excludeGenres = excludeGenresString.Split(';').ToList();
-            if (!string.IsNullOrEmpty(excludeGenresString))
-            {
-                // Add ? if it hasn't been added already
-                if (!_plugin.Settings.SkipMissingFiles)
-                {
-                    url += "?";
-                }
-
-                foreach (var genre in excludeGenres)
-                {
-                    url += $"genres={HttpUtility.UrlEncode(genre)}&";
-                }
-            }
-            return url.TrimEnd('&');
+            string baseUrl = _plugin.CombineUrl(_plugin.Settings.RomMHost, "api/roms");
+            return RomMRomQuery.Build(baseUrl, _plugin.Settings.SkipMissingFiles, _plugin.Settings.ExcludeGenres);
         }
         private IList<RomMPlatform> FetchPlatforms()
         {

--- a/Games/RomMInstallPaths.cs
+++ b/Games/RomMInstallPaths.cs
@@ -1,0 +1,19 @@
+using System.IO;
+
+namespace RomM.Games
+{
+    // Derives a ROM's install directory and playable path. These MUST come from the actual ROM file
+    // name (what gets downloaded), not the display name: using the display name drops the extension
+    // and can include characters that don't match the installed file, breaking IsInstalled detection
+    // and the play path.
+    internal static class RomMInstallPaths
+    {
+        // <root>/<file name without extension>
+        public static string InstallDir(string rootInstallDir, string fileName)
+            => Path.Combine(rootInstallDir, Path.GetFileNameWithoutExtension(fileName));
+
+        // <root>/<file name without extension>/<file name>
+        public static string GamePath(string rootInstallDir, string fileName)
+            => Path.Combine(InstallDir(rootInstallDir, fileName), fileName);
+    }
+}

--- a/Games/RomMRevisionFactory.cs
+++ b/Games/RomMRevisionFactory.cs
@@ -1,0 +1,55 @@
+using System.Collections.Generic;
+using System.Linq;
+using RomM.Models.RomM.Rom;
+
+namespace RomM.Games
+{
+    // Builds the per-ROM download descriptor (and selects the file to download). Pure so the
+    // single-file vs multi-file endpoint logic is unit-testable without the plugin runtime.
+    internal static class RomMRevisionFactory
+    {
+        // The file highest in the folder tree (fewest path separators); null when there are none.
+        public static RomMFile SelectPrimaryFile(IList<RomMFile> files)
+        {
+            if (files == null || files.Count == 0)
+                return null;
+
+            if (files.Count > 1)
+                return files.OrderBy(f => (f.FullPath ?? string.Empty).Count(c => c == '/')).FirstOrDefault();
+
+            return files.FirstOrDefault();
+        }
+
+        // Returns null when a single-file ROM has no resolvable file. Single files use the 4.9
+        // /files/content endpoint when a file id is present, falling back to the rom-level endpoint
+        // (so we never emit "api/roms//files/content/..."); multi-file ROMs download the whole archive.
+        public static RomMRevision Build(RomMRom rom, string romMHost)
+        {
+            var revision = new RomMRevision
+            {
+                Id = rom.Id,
+                HasMultipleFiles = rom.HasMultipleFiles,
+                IsSelected = false
+            };
+
+            if (!rom.HasMultipleFiles)
+            {
+                var romfile = SelectPrimaryFile(rom.Files);
+                if (romfile == null)
+                    return null;
+
+                revision.FileName = romfile.FileName;
+                revision.DownloadURL = romfile.Id.HasValue
+                    ? RomMUrl.Combine(romMHost, $"api/roms/{romfile.Id}/files/content/{romfile.FileName}")
+                    : RomMUrl.Combine(romMHost, $"api/roms/{rom.Id}/content/{romfile.FileName}");
+            }
+            else
+            {
+                revision.FileName = rom.FileName;
+                revision.DownloadURL = RomMUrl.Combine(romMHost, $"api/roms/{rom.Id}/content/{rom.FileName}");
+            }
+
+            return revision;
+        }
+    }
+}

--- a/Games/RomMRomQuery.cs
+++ b/Games/RomMRomQuery.cs
@@ -1,0 +1,32 @@
+using System.Web;
+
+namespace RomM.Games
+{
+    /// <summary>
+    /// Builds the "api/roms" query string (missing-file and genre-exclusion options) onto a base url.
+    /// Extracted as a pure helper so the query assembly is unit-testable without the plugin settings.
+    /// </summary>
+    internal static class RomMRomQuery
+    {
+        public static string Build(string romsBaseUrl, bool skipMissingFiles, string excludeGenres)
+        {
+            string url = romsBaseUrl;
+
+            if (skipMissingFiles)
+                url += "?missing=false&";
+
+            string genres = (excludeGenres ?? string.Empty).Trim(' ').Trim(';');
+            if (!string.IsNullOrEmpty(genres))
+            {
+                // Add the query separator only if the missing-files option hasn't already.
+                if (!skipMissingFiles)
+                    url += "?";
+
+                foreach (string genre in genres.Split(';'))
+                    url += $"genres={HttpUtility.UrlEncode(genre)}&";
+            }
+
+            return url.TrimEnd('&');
+        }
+    }
+}

--- a/Games/RomMServerVersion.cs
+++ b/Games/RomMServerVersion.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace RomM.Games
+{
+    /// <summary>
+    /// Decides whether a reported RomM server version is new enough to import from. Extracted as a
+    /// pure helper so the rule is unit-testable without the plugin/Playnite runtime.
+    /// </summary>
+    internal static class RomMServerVersion
+    {
+        private static readonly Version Minimum = new Version(4, 9);
+
+        /// <summary>
+        /// Returns true unless the version positively parses to something older than 4.9. Dev or
+        /// non-numeric versions (e.g. "development") are assumed compatible; pre-release suffixes
+        /// (e.g. "4.9.0-beta", "4.9.0+build") are stripped before parsing.
+        /// </summary>
+        public static bool SupportsImport(string version)
+        {
+            string raw = (version ?? string.Empty).Split('-', '+')[0];
+            if (Version.TryParse(raw, out Version parsed))
+                return parsed.CompareTo(Minimum) >= 0;
+
+            return true;
+        }
+    }
+}

--- a/Games/RomMSiblings.cs
+++ b/Games/RomMSiblings.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using RomM.Models.RomM.Rom;
+
+namespace RomM.Games
+{
+    // Classifies a ROM within a merged-revisions group. Pure so the main-sibling resolution is
+    // unit-testable; the importer passes its id->ROM index for the cross-sibling lookups.
+    internal static class RomMSiblings
+    {
+        public static MainSibling ClassifyMain(RomMRom rom, IReadOnlyDictionary<int, RomMRom> romsById)
+        {
+            // Is this ROM itself the main sibling?
+            if (rom.RomUser.IsMainSibling)
+                return MainSibling.Current;
+
+            // Is another sibling (present in this batch) the main one?
+            foreach (var sibling in rom.Siblings)
+            {
+                if (romsById.TryGetValue(sibling.Id, out var siblingRom) &&
+                    siblingRom.RomUser != null && siblingRom.RomUser.IsMainSibling)
+                {
+                    return MainSibling.Other;
+                }
+            }
+
+            return MainSibling.None;
+        }
+    }
+}

--- a/Games/RomMUrl.cs
+++ b/Games/RomMUrl.cs
@@ -1,0 +1,11 @@
+namespace RomM.Games
+{
+    // Pure url joining used across the plugin (RomM.CombineUrl delegates here). Trims a trailing
+    // slash off the base and a leading slash off the relative part so the two always join with exactly
+    // one separator, even when the payload omits or doubles them.
+    internal static class RomMUrl
+    {
+        public static string Combine(string baseUrl, string relativePath)
+            => $"{baseUrl?.TrimEnd('/')}/{relativePath?.TrimStart('/') ?? ""}";
+    }
+}

--- a/Models/RomM/Rom/GameInstallInfo.cs
+++ b/Models/RomM/Rom/GameInstallInfo.cs
@@ -1,0 +1,15 @@
+using RomM.Settings;
+
+namespace RomM.Models.RomM.Rom
+{
+    // Carries an EmulatorMapping (a Settings type), so it lives in its own file to keep the rest of
+    // RomMRomLocal.cs free of the RomM.Settings dependency and unit-testable.
+    public struct GameInstallInfo
+    {
+        public int Id { get; set; }
+        public string FileName { get; set; }
+        public bool HasMultipleFiles { get; set; }
+        public string DownloadURL { get; set; }
+        public EmulatorMapping Mapping { get; set; }
+    }
+}

--- a/Models/RomM/Rom/RomMRomLocal.cs
+++ b/Models/RomM/Rom/RomMRomLocal.cs
@@ -1,5 +1,4 @@
-﻿using RomM.Settings;
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace RomM.Models.RomM.Rom
@@ -9,15 +8,6 @@ namespace RomM.Models.RomM.Rom
         None = -1,
         Current = 0,
         Other = 1
-    }
-
-    public struct GameInstallInfo
-    {
-        public int Id { get; set; }
-        public string FileName { get; set; }
-        public bool HasMultipleFiles { get; set; }
-        public string DownloadURL { get; set; }
-        public EmulatorMapping Mapping { get; set; }
     }
 
     public class RomMRevision

--- a/RomM.Tests/RomM.Tests.csproj
+++ b/RomM.Tests/RomM.Tests.csproj
@@ -20,6 +20,7 @@
     </PackageReference>
     <PackageReference Include="PlayniteSDK" Version="6.16.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="protobuf-net" Version="2.0.0.668" />
   </ItemGroup>
 
   <!-- Framework assemblies the linked plugin sources need (no WPF). -->
@@ -40,6 +41,7 @@
       <Link>Linked\Models\%(RecursiveDir)%(Filename)%(Extension)</Link>
     </Compile>
     <Compile Include="..\Games\RomMGameId.cs" Link="Linked\Games\RomMGameId.cs" />
+    <Compile Include="..\Games\RomMGameInfo.cs" Link="Linked\Games\RomMGameInfo.cs" />
     <Compile Include="..\Games\RomMMetadataMapper.cs" Link="Linked\Games\RomMMetadataMapper.cs" />
     <Compile Include="..\Games\RomMServerVersion.cs" Link="Linked\Games\RomMServerVersion.cs" />
     <Compile Include="..\Games\RomMRomQuery.cs" Link="Linked\Games\RomMRomQuery.cs" />

--- a/RomM.Tests/RomM.Tests.csproj
+++ b/RomM.Tests/RomM.Tests.csproj
@@ -1,0 +1,48 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net462</TargetFramework>
+    <RootNamespace>RomM.Tests</RootNamespace>
+    <AssemblyName>RomM.Tests</AssemblyName>
+    <LangVersion>7.3</LangVersion>
+    <IsPackable>false</IsPackable>
+    <!-- Mirrors the release/PR build workaround for building net462 with the .NET 9 SDK on VS2026. -->
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Net.Sdk.Compilers.Toolset" Version="9.0.300" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="PlayniteSDK" Version="6.16.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+  </ItemGroup>
+
+  <!-- Framework assemblies the linked plugin sources need (no WPF). -->
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+
+  <!-- Source under test, linked rather than ProjectReference'd: the plugin project is WPF/XAML and
+       only builds under full msbuild, so we compile just the pure-logic files we exercise. -->
+  <ItemGroup>
+    <Compile Include="..\Models\**\*.cs" Exclude="..\Models\**\RomMRomLocal.cs">
+      <Link>Linked\Models\%(RecursiveDir)%(Filename)%(Extension)</Link>
+    </Compile>
+    <Compile Include="..\Games\RomMGameId.cs" Link="Linked\Games\RomMGameId.cs" />
+    <Compile Include="..\Games\RomMMetadataMapper.cs" Link="Linked\Games\RomMMetadataMapper.cs" />
+    <Compile Include="..\Games\RomMServerVersion.cs" Link="Linked\Games\RomMServerVersion.cs" />
+    <Compile Include="..\Games\RomMRomQuery.cs" Link="Linked\Games\RomMRomQuery.cs" />
+  </ItemGroup>
+
+</Project>

--- a/RomM.Tests/RomM.Tests.csproj
+++ b/RomM.Tests/RomM.Tests.csproj
@@ -45,6 +45,12 @@
     <Compile Include="..\Games\RomMMetadataMapper.cs" Link="Linked\Games\RomMMetadataMapper.cs" />
     <Compile Include="..\Games\RomMServerVersion.cs" Link="Linked\Games\RomMServerVersion.cs" />
     <Compile Include="..\Games\RomMRomQuery.cs" Link="Linked\Games\RomMRomQuery.cs" />
+    <Compile Include="..\Games\RomMUrl.cs" Link="Linked\Games\RomMUrl.cs" />
+    <Compile Include="..\Games\RomMRevisionFactory.cs" Link="Linked\Games\RomMRevisionFactory.cs" />
+    <Compile Include="..\Games\RomMInstallPaths.cs" Link="Linked\Games\RomMInstallPaths.cs" />
+    <Compile Include="..\Games\RomMCompletionStatus.cs" Link="Linked\Games\RomMCompletionStatus.cs" />
+    <Compile Include="..\Games\RomMHash.cs" Link="Linked\Games\RomMHash.cs" />
+    <Compile Include="..\Games\RomMSiblings.cs" Link="Linked\Games\RomMSiblings.cs" />
   </ItemGroup>
 
 </Project>

--- a/RomM.Tests/RomM.Tests.csproj
+++ b/RomM.Tests/RomM.Tests.csproj
@@ -37,7 +37,7 @@
   <!-- Source under test, linked rather than ProjectReference'd: the plugin project is WPF/XAML and
        only builds under full msbuild, so we compile just the pure-logic files we exercise. -->
   <ItemGroup>
-    <Compile Include="..\Models\**\*.cs" Exclude="..\Models\**\RomMRomLocal.cs">
+    <Compile Include="..\Models\**\*.cs" Exclude="..\Models\**\GameInstallInfo.cs">
       <Link>Linked\Models\%(RecursiveDir)%(Filename)%(Extension)</Link>
     </Compile>
     <Compile Include="..\Games\RomMGameId.cs" Link="Linked\Games\RomMGameId.cs" />

--- a/RomM.Tests/RomMCompletionStatusTests.cs
+++ b/RomM.Tests/RomMCompletionStatusTests.cs
@@ -1,0 +1,53 @@
+using RomM.Games;
+using RomM.Models.RomM.Rom;
+using Xunit;
+
+namespace RomM.Tests
+{
+    public class RomMCompletionStatusTests
+    {
+        [Fact]
+        public void Now_playing_takes_precedence_over_status_and_backlog()
+        {
+            var name = RomMCompletionStatus.ResolvePlayniteStatusName(
+                new RomMRomUser { NowPlaying = true, Backlogged = true, Status = "finished" });
+
+            Assert.Equal("Playing", name);
+        }
+
+        [Fact]
+        public void Backlogged_when_not_now_playing()
+        {
+            var name = RomMCompletionStatus.ResolvePlayniteStatusName(
+                new RomMRomUser { Backlogged = true, Status = "finished" });
+
+            Assert.Equal("Plan to Play", name);
+        }
+
+        [Theory]
+        [InlineData("finished", "Beaten")]
+        [InlineData("completed_100", "Completed")]
+        [InlineData("retired", "Played")]
+        [InlineData("incomplete", "On Hold")]
+        [InlineData("never_playing", "Abandoned")]
+        [InlineData("not_played", "Not Played")]
+        public void Maps_known_status(string status, string expected)
+        {
+            Assert.Equal(expected, RomMCompletionStatus.ResolvePlayniteStatusName(new RomMRomUser { Status = status }));
+        }
+
+        [Fact]
+        public void Unknown_status_falls_back_to_not_played()
+        {
+            Assert.Equal("Not Played",
+                RomMCompletionStatus.ResolvePlayniteStatusName(new RomMRomUser { Status = "something_new" }));
+        }
+
+        [Fact]
+        public void Null_status_falls_back_to_not_played()
+        {
+            Assert.Equal("Not Played",
+                RomMCompletionStatus.ResolvePlayniteStatusName(new RomMRomUser { Status = null }));
+        }
+    }
+}

--- a/RomM.Tests/RomMGameIdTests.cs
+++ b/RomM.Tests/RomMGameIdTests.cs
@@ -1,0 +1,44 @@
+using RomM.Games;
+using Xunit;
+
+namespace RomM.Tests
+{
+    public class RomMGameIdTests
+    {
+        [Fact]
+        public void Parses_valid_id_and_sha1()
+        {
+            bool ok = RomMGameId.TryParse("123:abcdef0123", out int id, out string sha1);
+
+            Assert.True(ok);
+            Assert.Equal(123, id);
+            Assert.Equal("abcdef0123", sha1);
+        }
+
+        [Fact]
+        public void Accepts_numeric_id_with_empty_sha1()
+        {
+            bool ok = RomMGameId.TryParse("123:", out int id, out string sha1);
+
+            Assert.True(ok);
+            Assert.Equal(123, id);
+            Assert.Equal("", sha1);
+        }
+
+        [Theory]
+        [InlineData(null)]            // null
+        [InlineData("")]             // empty
+        [InlineData("123")]          // no separator
+        [InlineData("abc:def")]      // non-numeric id
+        [InlineData("12:34:56")]     // too many parts
+        [InlineData("!0Q0FCRQ==")]   // legacy protobuf id
+        public void Rejects_malformed_ids(string gameId)
+        {
+            bool ok = RomMGameId.TryParse(gameId, out int id, out string sha1);
+
+            Assert.False(ok);
+            // sha1 is only assigned once parsing succeeds, so it stays null on every rejection path.
+            Assert.Null(sha1);
+        }
+    }
+}

--- a/RomM.Tests/RomMGameInfoTests.cs
+++ b/RomM.Tests/RomMGameInfoTests.cs
@@ -1,0 +1,51 @@
+using System;
+using Playnite.SDK.Models;
+using RomM.Games;
+using Xunit;
+
+namespace RomM.Tests
+{
+    public class RomMGameInfoTests
+    {
+        [Fact]
+        public void AsGameId_round_trips_through_FromGame()
+        {
+            var info = new RomMGameInfo
+            {
+                MappingId = Guid.NewGuid(),
+                DownloadUrl = "https://romm.example.com/api/roms/5/content/file.gba",
+                FileName = "file.gba",
+                HasMultipleFiles = false,
+            };
+
+            string id = info.AsGameId();
+
+            // Legacy protobuf ids are base64 prefixed with "!0".
+            Assert.StartsWith("!0", id);
+
+            var back = RomMGameInfo.FromGame<RomMGameInfo>(new Game { GameId = id });
+
+            Assert.Equal(info.MappingId, back.MappingId);
+            Assert.Equal(info.DownloadUrl, back.DownloadUrl);
+            Assert.Equal(info.FileName, back.FileName);
+            Assert.Equal(info.HasMultipleFiles, back.HasMultipleFiles);
+        }
+
+        [Fact]
+        public void AsGameId_round_trips_multifile_flag_and_via_metadata()
+        {
+            var info = new RomMGameInfo
+            {
+                MappingId = Guid.Empty,
+                FileName = "disc.m3u",
+                HasMultipleFiles = true,
+            };
+
+            var back = RomMGameInfo.FromGameMetadata<RomMGameInfo>(new GameMetadata { GameId = info.AsGameId() });
+
+            Assert.True(back.HasMultipleFiles);
+            Assert.Equal("disc.m3u", back.FileName);
+            Assert.Equal(Guid.Empty, back.MappingId);
+        }
+    }
+}

--- a/RomM.Tests/RomMHashTests.cs
+++ b/RomM.Tests/RomMHashTests.cs
@@ -1,0 +1,34 @@
+using RomM.Games;
+using Xunit;
+
+namespace RomM.Tests
+{
+    public class RomMHashTests
+    {
+        [Fact]
+        public void Produces_40_char_lowercase_hex()
+        {
+            var hash = RomMHash.FallbackSha1Hex(5, "Advance Wars");
+
+            Assert.Equal(40, hash.Length);
+            Assert.Matches("^[0-9a-f]{40}$", hash);
+        }
+
+        [Fact]
+        public void Is_deterministic()
+        {
+            Assert.Equal(
+                RomMHash.FallbackSha1Hex(5, "Advance Wars"),
+                RomMHash.FallbackSha1Hex(5, "Advance Wars"));
+        }
+
+        [Fact]
+        public void Varies_with_both_id_and_name()
+        {
+            var baseline = RomMHash.FallbackSha1Hex(5, "Advance Wars");
+
+            Assert.NotEqual(baseline, RomMHash.FallbackSha1Hex(6, "Advance Wars"));
+            Assert.NotEqual(baseline, RomMHash.FallbackSha1Hex(5, "Advance Wars 2"));
+        }
+    }
+}

--- a/RomM.Tests/RomMInstallPathsTests.cs
+++ b/RomM.Tests/RomMInstallPathsTests.cs
@@ -1,0 +1,35 @@
+using System.IO;
+using RomM.Games;
+using Xunit;
+
+namespace RomM.Tests
+{
+    public class RomMInstallPathsTests
+    {
+        private const string Root = "GAMES_ROOT";
+
+        [Fact]
+        public void InstallDir_is_root_plus_filename_without_extension()
+        {
+            Assert.Equal(
+                Path.Combine(Root, "Advance Wars (USA)"),
+                RomMInstallPaths.InstallDir(Root, "Advance Wars (USA).gba"));
+        }
+
+        [Fact]
+        public void GamePath_is_install_dir_plus_full_filename()
+        {
+            const string fileName = "Advance Wars (USA).gba";
+            Assert.Equal(
+                Path.Combine(Root, "Advance Wars (USA)", fileName),
+                RomMInstallPaths.GamePath(Root, fileName));
+        }
+
+        [Fact]
+        public void Handles_filename_without_extension()
+        {
+            Assert.Equal(Path.Combine(Root, "game"), RomMInstallPaths.InstallDir(Root, "game"));
+            Assert.Equal(Path.Combine(Root, "game", "game"), RomMInstallPaths.GamePath(Root, "game"));
+        }
+    }
+}

--- a/RomM.Tests/RomMMetadataMapperTests.cs
+++ b/RomM.Tests/RomMMetadataMapperTests.cs
@@ -1,0 +1,213 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Playnite.SDK.Models;
+using RomM.Games;
+using RomM.Models.RomM.Rom;
+using Xunit;
+
+namespace RomM.Tests
+{
+    public class RomMMetadataMapperTests
+    {
+        private const string Host = "https://romm.example.com";
+        private static readonly DateTime UnixEpoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        // Minimal rom with the non-null members BuildBaseMetadata dereferences.
+        private static RomMRom NewRom()
+        {
+            return new RomMRom
+            {
+                Name = "Advance Wars",
+                Summary = "A turn-based strategy game.",
+                Metadatum = new metadatum(),
+                RomUser = new RomMRomUser(),
+                Regions = new List<string>(),
+            };
+        }
+
+        private static string[] Names(IEnumerable<MetadataProperty> props)
+        {
+            if (props == null)
+                return new string[0];
+
+            return props.OfType<MetadataNameProperty>().Select(p => p.Name).OrderBy(n => n).ToArray();
+        }
+
+        private static GameMetadata Map(RomMRom rom, string board = "ESRB")
+        {
+            return RomMMetadataMapper.BuildBaseMetadata(rom, Host, board);
+        }
+
+        [Fact]
+        public void Maps_name_and_description()
+        {
+            var md = Map(NewRom());
+
+            Assert.Equal("Advance Wars", md.Name);
+            Assert.Equal("A turn-based strategy game.", md.Description);
+        }
+
+        [Fact]
+        public void Icon_uses_miximage_path_under_resource_mount()
+        {
+            var rom = NewRom();
+            rom.SSMetadata = new RomMSSMetadata { MiximagePath = "roms/2/32/miximage/miximage.png" };
+
+            var md = Map(rom);
+
+            Assert.NotNull(md.Icon);
+            Assert.Equal(Host + "/assets/romm/resources/roms/2/32/miximage/miximage.png", md.Icon.Path);
+        }
+
+        [Fact]
+        public void Icon_falls_back_to_miximage_url_when_no_path()
+        {
+            var rom = NewRom();
+            rom.SSMetadata = new RomMSSMetadata { MiximageUrl = "https://ss.example/mix.png" };
+
+            var md = Map(rom);
+
+            Assert.NotNull(md.Icon);
+            Assert.Equal("https://ss.example/mix.png", md.Icon.Path);
+        }
+
+        [Fact]
+        public void Icon_prefers_path_over_url()
+        {
+            var rom = NewRom();
+            rom.SSMetadata = new RomMSSMetadata
+            {
+                MiximagePath = "roms/2/32/miximage/miximage.png",
+                MiximageUrl = "https://ss.example/mix.png",
+            };
+
+            var md = Map(rom);
+
+            Assert.Equal(Host + "/assets/romm/resources/roms/2/32/miximage/miximage.png", md.Icon.Path);
+        }
+
+        [Fact]
+        public void Icon_is_null_without_ss_metadata()
+        {
+            Assert.Null(Map(NewRom()).Icon);
+        }
+
+        [Fact]
+        public void Icon_is_null_when_miximage_absent()
+        {
+            var rom = NewRom();
+            rom.SSMetadata = new RomMSSMetadata();
+
+            Assert.Null(Map(rom).Icon);
+        }
+
+        [Fact]
+        public void Cover_uses_host_plus_path_without_resource_mount()
+        {
+            var rom = NewRom();
+            rom.PathCoverL = "/assets/romm/resources/roms/2/32/cover/big.png";
+
+            var md = Map(rom);
+
+            Assert.NotNull(md.CoverImage);
+            Assert.Equal(Host + "/assets/romm/resources/roms/2/32/cover/big.png", md.CoverImage.Path);
+        }
+
+        [Fact]
+        public void Cover_is_null_without_path()
+        {
+            Assert.Null(Map(NewRom()).CoverImage);
+        }
+
+        [Fact]
+        public void Maps_collection_fields_and_skips_empty_strings()
+        {
+            var rom = NewRom();
+            rom.Metadatum.Genres = new List<string> { "Strategy", "", "Tactics" };
+            rom.Metadatum.Franchises = new List<string> { "Advance Wars" };
+            rom.Metadatum.Gamemodes = new List<string> { "Single player" };
+            rom.Metadatum.Collections = new List<string> { "Nintendo" };
+            rom.Regions = new List<string> { "USA", "" };
+
+            var md = Map(rom);
+
+            Assert.Equal(new[] { "Strategy", "Tactics" }, Names(md.Genres));
+            Assert.Equal(new[] { "Advance Wars" }, Names(md.Series));
+            Assert.Equal(new[] { "Single player" }, Names(md.Features));
+            Assert.Equal(new[] { "Nintendo" }, Names(md.Categories));
+            Assert.Equal(new[] { "USA" }, Names(md.Regions));
+        }
+
+        [Fact]
+        public void Age_ratings_keep_only_preferred_board()
+        {
+            var rom = NewRom();
+            rom.Metadatum.Age_Ratings = new List<string> { "ESRB:Everyone", "PEGI:3" };
+
+            var md = Map(rom, board: "ESRB");
+
+            Assert.Equal(new[] { "ESRB:Everyone" }, Names(md.AgeRatings));
+        }
+
+        [Fact]
+        public void Age_ratings_null_when_none_present()
+        {
+            Assert.Null(Map(NewRom()).AgeRatings);
+        }
+
+        [Fact]
+        public void Builds_external_links_for_present_ids()
+        {
+            var rom = NewRom();
+            rom.SSId = 190935;
+            rom.HasheousId = 42;
+            rom.RAId = 7;
+            rom.HLTBId = 99;
+
+            var md = Map(rom);
+
+            Assert.Equal(4, md.Links.Count);
+            Assert.Contains(md.Links, l => l.Name == "Screenscraper" && l.Url.Contains("gameid=190935"));
+            Assert.Contains(md.Links, l => l.Name == "Hasheous" && l.Url.Contains("id=42"));
+            Assert.Contains(md.Links, l => l.Name == "RetroAchievements" && l.Url.EndsWith("/game/7"));
+            Assert.Contains(md.Links, l => l.Name == "HowLongToBeat" && l.Url.EndsWith("/game/99"));
+        }
+
+        [Fact]
+        public void No_links_when_no_ids()
+        {
+            Assert.Empty(Map(NewRom()).Links);
+        }
+
+        [Fact]
+        public void Maps_scores_and_last_activity()
+        {
+            var rom = NewRom();
+            rom.Metadatum.Average_Rating = 7.5f;
+            rom.RomUser.Rating = 8;
+            rom.RomUser.LastPlayed = new DateTime(2024, 1, 2, 3, 4, 5, DateTimeKind.Utc);
+
+            var md = Map(rom);
+
+            Assert.Equal(7, md.CommunityScore);  // 1-10 float truncated to int
+            Assert.Equal(80, md.UserScore);      // 1-10 rating scaled to Playnite's 1-100
+            Assert.Equal(rom.RomUser.LastPlayed, md.LastActivity);
+        }
+
+        [Fact]
+        public void Maps_release_date_from_epoch_milliseconds()
+        {
+            var rom = NewRom();
+            long ms = 1_700_000_000_000L;
+            rom.Metadatum.Release_Date = ms;
+
+            var md = Map(rom);
+
+            // Recompute identically (incl. ToLocalTime) so the assertion is timezone-stable.
+            var expected = new ReleaseDate(UnixEpoch.AddMilliseconds(ms).ToLocalTime());
+            Assert.True(md.ReleaseDate.HasValue);
+            Assert.Equal(expected, md.ReleaseDate.Value);
+        }
+    }
+}

--- a/RomM.Tests/RomMPlatformTests.cs
+++ b/RomM.Tests/RomMPlatformTests.cs
@@ -1,0 +1,51 @@
+using RomM.Models.RomM.Platform;
+using Xunit;
+
+namespace RomM.Tests
+{
+    public class RomMPlatformTests
+    {
+        [Fact]
+        public void Equal_when_names_match_regardless_of_id()
+        {
+            var a = new RomMPlatform { Name = "Game Boy Advance", Id = 1 };
+            var b = new RomMPlatform { Name = "Game Boy Advance", Id = 2 };
+
+            Assert.True(a.Equals(b));
+            Assert.True(a == b);
+            Assert.False(a != b);
+            Assert.Equal(a.GetHashCode(), b.GetHashCode());
+        }
+
+        [Fact]
+        public void Not_equal_when_names_differ()
+        {
+            var a = new RomMPlatform { Name = "Game Boy Advance" };
+            var b = new RomMPlatform { Name = "Super Nintendo" };
+
+            Assert.False(a.Equals(b));
+            Assert.True(a != b);
+        }
+
+        [Fact]
+        public void Null_name_yields_zero_hashcode_and_equals_other_null_name()
+        {
+            var a = new RomMPlatform { Name = null };
+            var b = new RomMPlatform { Name = null };
+
+            Assert.Equal(0, a.GetHashCode());
+            Assert.True(a.Equals(b));
+        }
+
+        [Fact]
+        public void Comparisons_with_null_are_safe()
+        {
+            var a = new RomMPlatform { Name = "Game Boy Advance" };
+
+            Assert.False(a == null);
+            Assert.True(a != null);
+            Assert.False(a.Equals((object)null));
+            Assert.False(a.Equals((RomMPlatform)null));
+        }
+    }
+}

--- a/RomM.Tests/RomMRevisionFactoryTests.cs
+++ b/RomM.Tests/RomMRevisionFactoryTests.cs
@@ -1,0 +1,90 @@
+using System.Collections.Generic;
+using RomM.Games;
+using RomM.Models.RomM.Rom;
+using Xunit;
+
+namespace RomM.Tests
+{
+    public class RomMRevisionFactoryTests
+    {
+        private const string Host = "https://romm.example.com";
+
+        [Fact]
+        public void SelectPrimaryFile_picks_shallowest_path()
+        {
+            var files = new List<RomMFile>
+            {
+                new RomMFile { FileName = "deep.gba", FullPath = "a/b/c/deep.gba" },
+                new RomMFile { FileName = "shallow.gba", FullPath = "a/shallow.gba" },
+            };
+
+            Assert.Equal("shallow.gba", RomMRevisionFactory.SelectPrimaryFile(files).FileName);
+        }
+
+        [Fact]
+        public void SelectPrimaryFile_null_when_empty_or_null()
+        {
+            Assert.Null(RomMRevisionFactory.SelectPrimaryFile(new List<RomMFile>()));
+            Assert.Null(RomMRevisionFactory.SelectPrimaryFile(null));
+        }
+
+        [Fact]
+        public void Single_file_with_id_uses_files_content_endpoint()
+        {
+            var rom = new RomMRom
+            {
+                Id = 32,
+                HasMultipleFiles = false,
+                Files = new List<RomMFile> { new RomMFile { Id = 7, FileName = "game.gba", FullPath = "game.gba" } },
+            };
+
+            var rev = RomMRevisionFactory.Build(rom, Host);
+
+            Assert.NotNull(rev);
+            Assert.False(rev.HasMultipleFiles);
+            Assert.Equal("game.gba", rev.FileName);
+            Assert.Equal(Host + "/api/roms/7/files/content/game.gba", rev.DownloadURL);
+        }
+
+        [Fact]
+        public void Single_file_without_id_falls_back_to_rom_endpoint()
+        {
+            var rom = new RomMRom
+            {
+                Id = 32,
+                HasMultipleFiles = false,
+                Files = new List<RomMFile> { new RomMFile { Id = null, FileName = "game.gba", FullPath = "game.gba" } },
+            };
+
+            var rev = RomMRevisionFactory.Build(rom, Host);
+
+            Assert.Equal(Host + "/api/roms/32/content/game.gba", rev.DownloadURL);
+        }
+
+        [Fact]
+        public void Single_file_returns_null_when_no_files()
+        {
+            var rom = new RomMRom { Id = 32, HasMultipleFiles = false, Files = new List<RomMFile>() };
+
+            Assert.Null(RomMRevisionFactory.Build(rom, Host));
+        }
+
+        [Fact]
+        public void Multi_file_uses_rom_content_endpoint()
+        {
+            var rom = new RomMRom
+            {
+                Id = 40,
+                HasMultipleFiles = true,
+                FileName = "Game (Disc).zip",
+                Files = new List<RomMFile>(),
+            };
+
+            var rev = RomMRevisionFactory.Build(rom, Host);
+
+            Assert.True(rev.HasMultipleFiles);
+            Assert.Equal("Game (Disc).zip", rev.FileName);
+            Assert.Equal(Host + "/api/roms/40/content/Game (Disc).zip", rev.DownloadURL);
+        }
+    }
+}

--- a/RomM.Tests/RomMRomQueryTests.cs
+++ b/RomM.Tests/RomMRomQueryTests.cs
@@ -1,0 +1,54 @@
+using RomM.Games;
+using Xunit;
+
+namespace RomM.Tests
+{
+    public class RomMRomQueryTests
+    {
+        private const string Base = "https://romm.example.com/api/roms";
+
+        [Fact]
+        public void No_options_returns_base_url()
+        {
+            Assert.Equal(Base, RomMRomQuery.Build(Base, false, null));
+        }
+
+        [Fact]
+        public void Skip_missing_files_only()
+        {
+            Assert.Equal(Base + "?missing=false", RomMRomQuery.Build(Base, true, null));
+        }
+
+        [Fact]
+        public void Single_excluded_genre()
+        {
+            Assert.Equal(Base + "?genres=Adventure", RomMRomQuery.Build(Base, false, "Adventure"));
+        }
+
+        [Fact]
+        public void Multiple_excluded_genres_with_missing_files()
+        {
+            Assert.Equal(
+                Base + "?missing=false&genres=Adventure&genres=RPG",
+                RomMRomQuery.Build(Base, true, "Adventure;RPG"));
+        }
+
+        [Fact]
+        public void Trims_surrounding_whitespace_and_trailing_semicolons()
+        {
+            Assert.Equal(Base + "?genres=Adventure", RomMRomQuery.Build(Base, false, "  Adventure;  "));
+        }
+
+        [Fact]
+        public void Url_encodes_spaces_in_genre_names()
+        {
+            Assert.Equal(Base + "?genres=Role+Playing", RomMRomQuery.Build(Base, false, "Role Playing"));
+        }
+
+        [Fact]
+        public void Blank_genre_string_adds_no_query()
+        {
+            Assert.Equal(Base, RomMRomQuery.Build(Base, false, ";;"));
+        }
+    }
+}

--- a/RomM.Tests/RomMRomTests.cs
+++ b/RomM.Tests/RomMRomTests.cs
@@ -1,0 +1,81 @@
+using Newtonsoft.Json;
+using RomM.Models.RomM.Rom;
+using Xunit;
+
+namespace RomM.Tests
+{
+    public class RomMRomTests
+    {
+        // Mirrors the real /api/roms payload shape, including the keys that have drifted historically
+        // (sibling_roms, sha1_hash) and the Screenscraper media we map to the icon.
+        private const string FullRomJson = @"{
+            ""id"": 32,
+            ""name"": ""Advance Wars"",
+            ""sha1_hash"": ""deadbeef"",
+            ""fs_name"": ""Advance Wars (USA).gba"",
+            ""platform_name"": ""Game Boy Advance"",
+            ""metadatum"": {
+                ""genres"": [""Strategy"", ""Tactics""],
+                ""first_release_date"": 1280793600,
+                ""average_rating"": 8.5
+            },
+            ""ss_metadata"": {
+                ""miximage_path"": ""roms/2/32/miximage/miximage.png"",
+                ""miximage_url"": ""https://neoclone.screenscraper.fr/api2/mediaJeu.php?media=mixrbv1""
+            },
+            ""sibling_roms"": [
+                { ""id"": 33, ""name"": ""Advance Wars 2"", ""fs_name_no_ext"": ""Advance Wars 2"" }
+            ],
+            ""rom_user"": {
+                ""rating"": 8,
+                ""last_played"": ""2024-01-02T03:04:05Z""
+            }
+        }";
+
+        [Fact]
+        public void Deserializes_core_nested_and_drifted_fields()
+        {
+            var rom = JsonConvert.DeserializeObject<RomMRom>(FullRomJson);
+
+            Assert.Equal(32, rom.Id);
+            Assert.Equal("Advance Wars", rom.Name);
+            Assert.Equal("deadbeef", rom.SHA1);
+
+            Assert.Contains("Strategy", rom.Metadatum.Genres);
+            Assert.Contains("Tactics", rom.Metadatum.Genres);
+            Assert.Equal(8.5f, rom.Metadatum.Average_Rating);
+
+            Assert.Equal("roms/2/32/miximage/miximage.png", rom.SSMetadata.MiximagePath);
+            Assert.StartsWith("https://", rom.SSMetadata.MiximageUrl);
+
+            Assert.Single(rom.Siblings);
+            Assert.Equal(33, rom.Siblings[0].Id);
+            Assert.Equal("Advance Wars 2", rom.Siblings[0].Name);
+
+            Assert.Equal(8, rom.RomUser.Rating);
+            Assert.True(rom.RomUser.LastPlayed.HasValue);
+        }
+
+        [Fact]
+        public void Normalize_fills_missing_collections_and_objects()
+        {
+            var rom = JsonConvert.DeserializeObject<RomMRom>(@"{ ""id"": 5, ""name"": ""x"" }");
+
+            // RomM 4.9+ can omit these entirely; they deserialize as null.
+            Assert.Null(rom.RomUser);
+            Assert.Null(rom.Metadatum);
+            Assert.Null(rom.Siblings);
+
+            rom.Normalize();
+
+            Assert.NotNull(rom.Metadatum);
+            Assert.NotNull(rom.RomUser);
+            Assert.NotNull(rom.Regions);
+            Assert.NotNull(rom.Tags);
+            Assert.NotNull(rom.Files);
+            Assert.NotNull(rom.Siblings);
+            // metadatum initialises its own collections, so consumers never null-check them either.
+            Assert.NotNull(rom.Metadatum.Genres);
+        }
+    }
+}

--- a/RomM.Tests/RomMServerVersionTests.cs
+++ b/RomM.Tests/RomMServerVersionTests.cs
@@ -1,0 +1,33 @@
+using RomM.Games;
+using Xunit;
+
+namespace RomM.Tests
+{
+    public class RomMServerVersionTests
+    {
+        [Theory]
+        // Supported: 4.9 and newer.
+        [InlineData("4.9", true)]
+        [InlineData("4.9.0", true)]
+        [InlineData("4.10", true)]
+        [InlineData("5.0", true)]
+        [InlineData("10.0.0", true)]
+        // Pre-release / build suffixes are stripped, then compared.
+        [InlineData("4.9.0-beta", true)]
+        [InlineData("4.9.0-beta.1", true)]
+        [InlineData("4.9.0+build7", true)]
+        // Dev / non-numeric / missing versions are assumed compatible.
+        [InlineData("development", true)]
+        [InlineData("", true)]
+        [InlineData(null, true)]
+        // Positively-too-old versions are blocked.
+        [InlineData("4.8", false)]
+        [InlineData("4.8.9", false)]
+        [InlineData("3.0", false)]
+        [InlineData("4.8.0-beta", false)]
+        public void SupportsImport_classifies_versions(string version, bool expected)
+        {
+            Assert.Equal(expected, RomMServerVersion.SupportsImport(version));
+        }
+    }
+}

--- a/RomM.Tests/RomMSiblingsTests.cs
+++ b/RomM.Tests/RomMSiblingsTests.cs
@@ -1,0 +1,55 @@
+using System.Collections.Generic;
+using RomM.Games;
+using RomM.Models.RomM.Rom;
+using Xunit;
+
+namespace RomM.Tests
+{
+    public class RomMSiblingsTests
+    {
+        private static RomMRom Rom(int id, bool isMain, params int[] siblingIds)
+        {
+            var rom = new RomMRom
+            {
+                Id = id,
+                RomUser = new RomMRomUser { IsMainSibling = isMain },
+                Siblings = new List<RomMSibling>(),
+            };
+            foreach (var sid in siblingIds)
+                rom.Siblings.Add(new RomMSibling { Id = sid });
+            return rom;
+        }
+
+        [Fact]
+        public void Current_when_rom_itself_is_main()
+        {
+            Assert.Equal(MainSibling.Current,
+                RomMSiblings.ClassifyMain(Rom(1, true), new Dictionary<int, RomMRom>()));
+        }
+
+        [Fact]
+        public void Other_when_a_sibling_in_batch_is_main()
+        {
+            var main = Rom(2, true);
+            var byId = new Dictionary<int, RomMRom> { { 2, main } };
+
+            Assert.Equal(MainSibling.Other, RomMSiblings.ClassifyMain(Rom(1, false, 2), byId));
+        }
+
+        [Fact]
+        public void None_when_sibling_not_present_in_batch()
+        {
+            Assert.Equal(MainSibling.None,
+                RomMSiblings.ClassifyMain(Rom(1, false, 99), new Dictionary<int, RomMRom>()));
+        }
+
+        [Fact]
+        public void None_when_no_sibling_is_main()
+        {
+            var sibling = Rom(2, false);
+            var byId = new Dictionary<int, RomMRom> { { 2, sibling } };
+
+            Assert.Equal(MainSibling.None, RomMSiblings.ClassifyMain(Rom(1, false, 2), byId));
+        }
+    }
+}

--- a/RomM.Tests/RomMUrlTests.cs
+++ b/RomM.Tests/RomMUrlTests.cs
@@ -1,0 +1,25 @@
+using RomM.Games;
+using Xunit;
+
+namespace RomM.Tests
+{
+    public class RomMUrlTests
+    {
+        [Theory]
+        [InlineData("https://h", "api/roms", "https://h/api/roms")]
+        [InlineData("https://h/", "api/roms", "https://h/api/roms")]
+        [InlineData("https://h", "/api/roms", "https://h/api/roms")]
+        [InlineData("https://h/", "/api/roms", "https://h/api/roms")]
+        [InlineData("https://h///", "///api/roms", "https://h/api/roms")]
+        public void Combine_joins_with_exactly_one_slash(string baseUrl, string relative, string expected)
+        {
+            Assert.Equal(expected, RomMUrl.Combine(baseUrl, relative));
+        }
+
+        [Fact]
+        public void Null_relative_yields_base_with_trailing_slash()
+        {
+            Assert.Equal("https://h/", RomMUrl.Combine("https://h", null));
+        }
+    }
+}

--- a/RomM.cs
+++ b/RomM.cs
@@ -108,10 +108,7 @@ namespace RomM
 
 
     #region Helper functions
-        public string CombineUrl(string baseUrl, string relativePath)
-        {
-            return $"{baseUrl?.TrimEnd('/')}/{relativePath?.TrimStart('/') ?? ""}";
-        }
+        public string CombineUrl(string baseUrl, string relativePath) => RomMUrl.Combine(baseUrl, relativePath);
 
         public RomMRom FetchRom(string romId)
         {

--- a/RomM.csproj
+++ b/RomM.csproj
@@ -12,6 +12,12 @@
     <Deterministic>true</Deterministic>
     <ProjectGuid>{2351B5C1-6E28-4B79-A1D9-90FDA53B5417}</ProjectGuid>
   </PropertyGroup>
+  <!-- The test project lives under RomM.Tests/ and links source files directly; keep its files
+       out of the plugin's default **/*.cs globbing so the plugin build ignores them. -->
+  <ItemGroup>
+    <Compile Remove="RomM.Tests\**\*.cs" />
+    <None Remove="RomM.Tests\**\*" />
+  </ItemGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>


### PR DESCRIPTION
Introduces an xUnit (net462) test project that links the plugin's pure-logic
source files directly instead of project-referencing the WPF/XAML plugin (which
only builds under full msbuild), so the suite builds and runs under `dotnet test`.

Coverage:
- RomMGameId.TryParse (id:sha1 parsing, legacy/malformed rejection)
- RomMMetadataMapper.BuildBaseMetadata (icon precedence miximage path->url, cover
  url, genres/regions/series/features/categories, age-rating board filter, links,
  scores, release date)
- RomMRom JSON deserialization + Normalize (guards model drift: sibling_roms,
  sha1_hash, ss_metadata)
- RomMPlatform equality/hashcode contract

Extracts two pure seams from RomMImportController so they're testable without the
plugin runtime:
- RomMServerVersion.SupportsImport (>= 4.9 gate; dev/pre-release handling)
- RomMRomQuery.Build (api/roms query: missing + genre exclusions)

CI: new test.yml runs the suite on push/PR (Windows), and compiles the plugin on
push so seam refactors stay verified. The plugin project excludes RomM.Tests from
its default globbing.