### PR TITLE
fix(settings): auto-sync RomM platforms on connect, drop manual button reliance

### DIFF
--- a/Settings/Settings.cs
+++ b/Settings/Settings.cs
@@ -388,6 +388,11 @@ namespace RomM.Settings
                     ServerVersion = info.Version;
                 }
 
+                // Sync the RomM platform list so the mapping dropdowns populate and import can resolve
+                // each mapping's platform — no manual "Sync RomM platforms" click required. Runs for both
+                // the settings "Authenticate" action and the pre-import connection check.
+                SyncPlatforms();
+
                 // Profile (name/role/avatar) is only needed for the settings UI, not for import.
                 if (fetchProfile)
                 {
@@ -443,6 +448,28 @@ namespace RomM.Settings
             }
 
             return true;
+        }
+
+        // Fetches the RomM platform list and assigns it to RomMPlatforms, which propagates to every
+        // mapping's AvailablePlatforms (populating the dropdowns and resolving the selected platform).
+        // Failures are logged but never block authentication or import.
+        private void SyncPlatforms()
+        {
+            try
+            {
+                HttpResponseMessage response = HttpClientSingleton.Instance.GetAsync(
+                    $"{RomMHost}/api/platforms",
+                    HttpCompletionOption.ResponseContentRead,
+                    new System.Threading.CancellationTokenSource(TimeSpan.FromSeconds(30)).Token).GetAwaiter().GetResult();
+                response.EnsureSuccessStatusCode();
+
+                string body = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+                RomMPlatforms = JsonConvert.DeserializeObject<List<RomMPlatform>>(body);
+            }
+            catch (Exception ex)
+            {
+                LogManager.GetLogger().Error($"[Settings] Failed to sync RomM platforms: {ex.Message}");
+            }
         }
 
         public void BeginEdit()

--- a/Settings/Settings.cs
+++ b/Settings/Settings.cs
@@ -457,18 +457,21 @@ namespace RomM.Settings
         {
             try
             {
-                HttpResponseMessage response = HttpClientSingleton.Instance.GetAsync(
+                using (var cts = new System.Threading.CancellationTokenSource(TimeSpan.FromSeconds(30)))
+                using (HttpResponseMessage response = HttpClientSingleton.Instance.GetAsync(
                     $"{RomMHost}/api/platforms",
                     HttpCompletionOption.ResponseContentRead,
-                    new System.Threading.CancellationTokenSource(TimeSpan.FromSeconds(30)).Token).GetAwaiter().GetResult();
-                response.EnsureSuccessStatusCode();
+                    cts.Token).GetAwaiter().GetResult())
+                {
+                    response.EnsureSuccessStatusCode();
 
-                string body = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
-                RomMPlatforms = JsonConvert.DeserializeObject<List<RomMPlatform>>(body);
+                    string body = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+                    RomMPlatforms = JsonConvert.DeserializeObject<List<RomMPlatform>>(body) ?? new List<RomMPlatform>();
+                }
             }
             catch (Exception ex)
             {
-                LogManager.GetLogger().Error($"[Settings] Failed to sync RomM platforms: {ex.Message}");
+                LogManager.GetLogger().Error($"[Settings] Failed to sync RomM platforms: {ex}");
             }
         }
 


### PR DESCRIPTION
Users were missing the "Sync RomM platforms" button, leaving the per-mapping platform dropdown empty — and since the selected platform is resolved at runtime from the synced list (RomMPlatform is JsonIgnore, only RomMPlatformId persists), an empty list means no selectable platform and no import.

Sync the platform list inside TestConnection's success path, which runs both when the user clicks "Authenticate" in settings (so the dropdowns populate immediately) and as the pre-import connection check (so import can resolve each mapping's platform). Failures are logged but never block auth or import. The manual button still works as a refresh but is no longer required.