### PR TITLE
Improve error handling for missing RomM platform after upgrade

### DIFF
--- a/Games/RomMImportController.cs
+++ b/Games/RomMImportController.cs
@@ -58,10 +58,29 @@ namespace RomM.Games
                 if (args.CancelToken.IsCancellationRequested)
                     break;
 
-                // Check mapping has an Emulator, Profile & Platform assigned to it
-                if (mapping.Emulator == null || mapping.EmulatorProfile == null || mapping.RomMPlatform == null || mapping.RomMPlatform.Id == -1)
+                // A mapping with no emulator/profile is genuinely unconfigured — skip quietly.
+                if (mapping.Emulator == null || mapping.EmulatorProfile == null)
                 {
                     Logger.Warn($"[Import Controller] Emulator {mapping.MappingId} is misconfigured, skipping.");
+                    continue;
+                }
+
+                // No RomM platform selected. This is the common state right after upgrading from a
+                // pre-0.6 version, where the old platform mapping is dropped and no RomM platform id
+                // is carried over. Give the user an actionable message instead of a cryptic
+                // "-1 not found". The <= 0 check covers both the unset RomMPlatformId (-1) and the
+                // empty default RomMPlatform (Id 0).
+                if (mapping.RomMPlatformId <= 0 || mapping.RomMPlatform == null || mapping.RomMPlatform.Id <= 0)
+                {
+                    var name = !string.IsNullOrWhiteSpace(mapping.MappingName)
+                        ? mapping.MappingName
+                        : (mapping.Emulator?.Name ?? "a mapping");
+                    // Stable per-mapping id so repeated imports dedupe instead of stacking.
+                    _plugin.Playnite.Notifications.Add(
+                        $"{_plugin.Id}-platform-unset-{mapping.MappingId}",
+                        $"The RomM platform for \"{name}\" is not set. This can happen after upgrading the plugin. " +
+                        "Open RomM settings, select the emulator mapping, choose its RomM platform, then run Update Game Library again.",
+                        NotificationType.Error);
                     continue;
                 }
 


### PR DESCRIPTION
## TL;DR
Added a clearer, actionable error message when users encounter missing RomM platform mappings after upgrading from pre-0.6 versions, replacing cryptic "-1 not found" errors with helpful guidance on how to reconfigure their settings.

## What changed?
- Split platform validation into two separate checks with distinct error handling:
  - Unconfigured emulator/profile mappings now fail silently (existing behavior)
  - Missing RomM platform selection now triggers a user-facing notification with actionable instructions
  
- Enhanced the missing platform detection to check both `RomMPlatformId <= 0` and `RomMPlatform` nullability, covering both unset mappings (-1) and empty defaults (0)

- Added a user-friendly error notification that:
  - Uses the mapping name or emulator name for clarity
  - Generates stable notification IDs per mapping to prevent duplicate notifications on repeated imports
  - Explains that this commonly occurs after plugin upgrades
  - Provides step-by-step instructions to resolve the issue

- Improved code comments explaining the upgrade migration scenario and why special handling is needed

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*