### PR TITLE
fix: prevent QR login code from overflowing settings layout

### DIFF
--- a/Settings/SettingsView.xaml
+++ b/Settings/SettingsView.xaml
@@ -109,51 +109,59 @@
                     <!-- Credentials -->
                     <Grid>
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="170"/>
                             <ColumnDefinition Width="Auto"/>
-                            <ColumnDefinition Width="Auto"/>
-                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
                         </Grid.ColumnDefinitions>
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="*"/>
-                            <RowDefinition Height="Auto"/>
-                        </Grid.RowDefinitions>
 
-                        <Label Grid.Row="0" Grid.Column="0" Content="RomM host" Style="{StaticResource FieldLabel}" />
-                        <TextBox Grid.Row="0" Grid.Column="1" Style="{StaticResource FieldBox}" Text="{Binding RomMHost, Mode=TwoWay}" />
+                        <!-- Left: credential fields -->
+                        <Grid Grid.Column="0">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="170"/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
 
-                        <TextBlock  Grid.Row="1" Grid.Column="0" VerticalAlignment="Center">
-                            <Hyperlink NavigateUri="{Binding ClientTokenURL}" RequestNavigate="Hyperlink_RequestNavigate">Client Token</Hyperlink>
-                        </TextBlock>
-                        <TextBox Grid.Row="1" Grid.Column="1" VerticalAlignment="Center" Style="{StaticResource FieldBox}" Text="{Binding RomMClientToken, Mode=TwoWay}" />
+                            <Label Grid.Row="0" Grid.Column="0" Content="RomM host" Style="{StaticResource FieldLabel}" />
+                            <TextBox Grid.Row="0" Grid.Column="1" Style="{StaticResource FieldBox}" Text="{Binding RomMHost, Mode=TwoWay}" />
 
-                        <CheckBox Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" Margin="0,0,0,6" VerticalAlignment="Center" Content="Use basic auth (username / password)" IsChecked="{Binding UseBasicAuth, Mode=TwoWay}" />
+                            <TextBlock Grid.Row="1" Grid.Column="0" VerticalAlignment="Center">
+                                <Hyperlink NavigateUri="{Binding ClientTokenURL}" RequestNavigate="Hyperlink_RequestNavigate">Client Token</Hyperlink>
+                            </TextBlock>
+                            <TextBox Grid.Row="1" Grid.Column="1" VerticalAlignment="Center" Style="{StaticResource FieldBox}" Text="{Binding RomMClientToken, Mode=TwoWay}" />
 
-                        <Label Grid.Row="3" Grid.Column="0" Content="Username" Style="{StaticResource FieldLabel}" Visibility="{Binding UseBasicAuth, Converter={StaticResource BoolToVisConverter}}" />
-                        <TextBox Grid.Row="3" Grid.Column="1" Style="{StaticResource FieldBox}" Text="{Binding RomMUsername, Mode=TwoWay}" Visibility="{Binding UseBasicAuth, Converter={StaticResource BoolToVisConverter}}" />
+                            <CheckBox Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" Margin="0,0,0,6" VerticalAlignment="Center" Content="Use basic auth (username / password)" IsChecked="{Binding UseBasicAuth, Mode=TwoWay}" />
 
-                        <Label Grid.Row="4" Grid.Column="0" Content="Password" Style="{StaticResource FieldLabel}" Visibility="{Binding UseBasicAuth, Converter={StaticResource BoolToVisConverter}}" />
-                        <TextBox Grid.Row="4" Grid.Column="1" Style="{StaticResource FieldBox}" Text="{Binding RomMPassword, Mode=TwoWay}" Visibility="{Binding UseBasicAuth, Converter={StaticResource BoolToVisConverter}}" />
+                            <Label Grid.Row="3" Grid.Column="0" Content="Username" Style="{StaticResource FieldLabel}" Visibility="{Binding UseBasicAuth, Converter={StaticResource BoolToVisConverter}}" />
+                            <TextBox Grid.Row="3" Grid.Column="1" Style="{StaticResource FieldBox}" Text="{Binding RomMUsername, Mode=TwoWay}" Visibility="{Binding UseBasicAuth, Converter={StaticResource BoolToVisConverter}}" />
 
-                        <Button Name="QRAuth" Click="Click_LoginViaQR" Grid.Row="0" Grid.Column="2" Margin="5" HorizontalAlignment="Left" VerticalAlignment="Center">
-                            <TextBlock Name="QRAuthText" Text="Login via QR Code" HorizontalAlignment="Center" VerticalAlignment="Center"/>
-                        </Button>
+                            <Label Grid.Row="4" Grid.Column="0" Content="Password" Style="{StaticResource FieldLabel}" Visibility="{Binding UseBasicAuth, Converter={StaticResource BoolToVisConverter}}" />
+                            <TextBox Grid.Row="4" Grid.Column="1" Style="{StaticResource FieldBox}" Text="{Binding RomMPassword, Mode=TwoWay}" Visibility="{Binding UseBasicAuth, Converter={StaticResource BoolToVisConverter}}" />
+                        </Grid>
 
-                        <!--<Image Name="LoginQR" Margin="20" Grid.Row="1" Grid.Column="2" Grid.RowSpan="5" Grid.ColumnSpan="2" Stretch="Uniform" MaxHeight="250" HorizontalAlignment="Center"/>-->
-                        <Border Name="LoginQRBorder" Visibility="Hidden" BorderThickness="1" CornerRadius="8" ClipToBounds="True" BorderBrush="#41373737" Background="#41373737" Margin="10" Grid.Row="1" Grid.Column="2" Grid.RowSpan="5" Grid.ColumnSpan="2" Height="{Binding ActualWidth, RelativeSource={RelativeSource Self}}"/>
-                        <Border Name="LoginQR" Panel.ZIndex="9999" Visibility="Hidden" BorderThickness="1" CornerRadius="8" ClipToBounds="True" Margin="10" Grid.Row="1" Grid.Column="2" Grid.RowSpan="5" Grid.ColumnSpan="2"  Height="{Binding ActualWidth, RelativeSource={RelativeSource Self}}"/>
-                        <StackPanel Name="QRDetails" Orientation="Horizontal" Grid.Row="6" Grid.Column="2" Grid.ColumnSpan="2" HorizontalAlignment="Center" Visibility="Hidden">
-                            <Button Click="Click_OpenInBrowser" Grid.Row="0" Grid.Column="2" Margin="5" HorizontalAlignment="Left" VerticalAlignment="Center" >
-                                <TextBlock Text="Open in Browser" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        <!-- Right: QR code login (sits in the layout flow so it never overlaps other sections) -->
+                        <StackPanel Grid.Column="1" Margin="16,0,0,0" HorizontalAlignment="Right" VerticalAlignment="Top">
+                            <Button Name="QRAuth" Click="Click_LoginViaQR" Padding="12,4" HorizontalAlignment="Right">
+                                <TextBlock Name="QRAuthText" Text="Login via QR Code" HorizontalAlignment="Center" VerticalAlignment="Center"/>
                             </Button>
-                            <TextBlock Name="LoginQRTimer" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+
+                            <Grid Name="QRPanel" Width="200" Height="200" Margin="0,10,0,0" HorizontalAlignment="Right" Visibility="Collapsed">
+                                <Border Name="LoginQRBorder" BorderThickness="1" CornerRadius="8" ClipToBounds="True" BorderBrush="#41373737" Background="#41373737"/>
+                                <Border Name="LoginQR" BorderThickness="1" CornerRadius="8" ClipToBounds="True"/>
+                            </Grid>
+
+                            <StackPanel Name="QRDetails" Orientation="Horizontal" Margin="0,8,0,0" HorizontalAlignment="Right" Visibility="Collapsed">
+                                <Button Click="Click_OpenInBrowser" Padding="12,4" VerticalAlignment="Center">
+                                    <TextBlock Text="Open in Browser" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                </Button>
+                                <TextBlock Name="LoginQRTimer" Margin="10,0,0,0" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                            </StackPanel>
                         </StackPanel>
-                        
                     </Grid>
 
                     <!-- Emulator path mappings -->

--- a/Settings/SettingsView.xaml
+++ b/Settings/SettingsView.xaml
@@ -109,60 +109,52 @@
                     <!-- Credentials -->
                     <Grid>
                         <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="170"/>
                             <ColumnDefinition Width="Auto"/>
-                            <ColumnDefinition Width="*"/>
                         </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
 
-                        <!-- Left: credential fields -->
-                        <Grid Grid.Column="0">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="170"/>
-                                <ColumnDefinition Width="Auto"/>
-                            </Grid.ColumnDefinitions>
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="Auto"/>
-                                <RowDefinition Height="Auto"/>
-                                <RowDefinition Height="Auto"/>
-                                <RowDefinition Height="Auto"/>
-                                <RowDefinition Height="Auto"/>
-                            </Grid.RowDefinitions>
+                        <Label Grid.Row="0" Grid.Column="0" Content="RomM host" Style="{StaticResource FieldLabel}" />
+                        <TextBox Grid.Row="0" Grid.Column="1" Style="{StaticResource FieldBox}" Text="{Binding RomMHost, Mode=TwoWay}" />
 
-                            <Label Grid.Row="0" Grid.Column="0" Content="RomM host" Style="{StaticResource FieldLabel}" />
-                            <TextBox Grid.Row="0" Grid.Column="1" Style="{StaticResource FieldBox}" Text="{Binding RomMHost, Mode=TwoWay}" />
+                        <TextBlock Grid.Row="1" Grid.Column="0" VerticalAlignment="Center">
+                            <Hyperlink NavigateUri="{Binding ClientTokenURL}" RequestNavigate="Hyperlink_RequestNavigate">Client Token</Hyperlink>
+                        </TextBlock>
+                        <TextBox Grid.Row="1" Grid.Column="1" VerticalAlignment="Center" Style="{StaticResource FieldBox}" Text="{Binding RomMClientToken, Mode=TwoWay}" />
 
-                            <TextBlock Grid.Row="1" Grid.Column="0" VerticalAlignment="Center">
-                                <Hyperlink NavigateUri="{Binding ClientTokenURL}" RequestNavigate="Hyperlink_RequestNavigate">Client Token</Hyperlink>
-                            </TextBlock>
-                            <TextBox Grid.Row="1" Grid.Column="1" VerticalAlignment="Center" Style="{StaticResource FieldBox}" Text="{Binding RomMClientToken, Mode=TwoWay}" />
+                        <CheckBox Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" Margin="0,0,0,6" VerticalAlignment="Center" Content="Use basic auth (username / password)" IsChecked="{Binding UseBasicAuth, Mode=TwoWay}" />
 
-                            <CheckBox Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" Margin="0,0,0,6" VerticalAlignment="Center" Content="Use basic auth (username / password)" IsChecked="{Binding UseBasicAuth, Mode=TwoWay}" />
+                        <Label Grid.Row="3" Grid.Column="0" Content="Username" Style="{StaticResource FieldLabel}" Visibility="{Binding UseBasicAuth, Converter={StaticResource BoolToVisConverter}}" />
+                        <TextBox Grid.Row="3" Grid.Column="1" Style="{StaticResource FieldBox}" Text="{Binding RomMUsername, Mode=TwoWay}" Visibility="{Binding UseBasicAuth, Converter={StaticResource BoolToVisConverter}}" />
 
-                            <Label Grid.Row="3" Grid.Column="0" Content="Username" Style="{StaticResource FieldLabel}" Visibility="{Binding UseBasicAuth, Converter={StaticResource BoolToVisConverter}}" />
-                            <TextBox Grid.Row="3" Grid.Column="1" Style="{StaticResource FieldBox}" Text="{Binding RomMUsername, Mode=TwoWay}" Visibility="{Binding UseBasicAuth, Converter={StaticResource BoolToVisConverter}}" />
+                        <Label Grid.Row="4" Grid.Column="0" Content="Password" Style="{StaticResource FieldLabel}" Visibility="{Binding UseBasicAuth, Converter={StaticResource BoolToVisConverter}}" />
+                        <TextBox Grid.Row="4" Grid.Column="1" Style="{StaticResource FieldBox}" Text="{Binding RomMPassword, Mode=TwoWay}" Visibility="{Binding UseBasicAuth, Converter={StaticResource BoolToVisConverter}}" />
+                    </Grid>
 
-                            <Label Grid.Row="4" Grid.Column="0" Content="Password" Style="{StaticResource FieldLabel}" Visibility="{Binding UseBasicAuth, Converter={StaticResource BoolToVisConverter}}" />
-                            <TextBox Grid.Row="4" Grid.Column="1" Style="{StaticResource FieldBox}" Text="{Binding RomMPassword, Mode=TwoWay}" Visibility="{Binding UseBasicAuth, Converter={StaticResource BoolToVisConverter}}" />
+                    <!-- QR code login (button and code stacked below the credentials, in the layout flow so it never overlaps other sections) -->
+                    <StackPanel Margin="0,8,0,0" HorizontalAlignment="Left">
+                        <Button Name="QRAuth" Click="Click_LoginViaQR" Padding="12,4" HorizontalAlignment="Left">
+                            <TextBlock Name="QRAuthText" Text="Login via QR Code" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Button>
+
+                        <Grid Name="QRPanel" Width="200" Height="200" Margin="0,10,0,0" HorizontalAlignment="Left" Visibility="Collapsed">
+                            <Border Name="LoginQRBorder" BorderThickness="1" CornerRadius="8" ClipToBounds="True" BorderBrush="#41373737" Background="#41373737"/>
+                            <Border Name="LoginQR" BorderThickness="1" CornerRadius="8" ClipToBounds="True"/>
                         </Grid>
 
-                        <!-- Right: QR code login (sits in the layout flow so it never overlaps other sections) -->
-                        <StackPanel Grid.Column="1" Margin="16,0,0,0" HorizontalAlignment="Right" VerticalAlignment="Top">
-                            <Button Name="QRAuth" Click="Click_LoginViaQR" Padding="12,4" HorizontalAlignment="Right">
-                                <TextBlock Name="QRAuthText" Text="Login via QR Code" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        <StackPanel Name="QRDetails" Orientation="Horizontal" Margin="0,8,0,0" HorizontalAlignment="Left" Visibility="Collapsed">
+                            <Button Click="Click_OpenInBrowser" Padding="12,4" VerticalAlignment="Center">
+                                <TextBlock Text="Open in Browser" HorizontalAlignment="Center" VerticalAlignment="Center"/>
                             </Button>
-
-                            <Grid Name="QRPanel" Width="200" Height="200" Margin="0,10,0,0" HorizontalAlignment="Right" Visibility="Collapsed">
-                                <Border Name="LoginQRBorder" BorderThickness="1" CornerRadius="8" ClipToBounds="True" BorderBrush="#41373737" Background="#41373737"/>
-                                <Border Name="LoginQR" BorderThickness="1" CornerRadius="8" ClipToBounds="True"/>
-                            </Grid>
-
-                            <StackPanel Name="QRDetails" Orientation="Horizontal" Margin="0,8,0,0" HorizontalAlignment="Right" Visibility="Collapsed">
-                                <Button Click="Click_OpenInBrowser" Padding="12,4" VerticalAlignment="Center">
-                                    <TextBlock Text="Open in Browser" HorizontalAlignment="Center" VerticalAlignment="Center"/>
-                                </Button>
-                                <TextBlock Name="LoginQRTimer" Margin="10,0,0,0" HorizontalAlignment="Center" VerticalAlignment="Center"/>
-                            </StackPanel>
+                            <TextBlock Name="LoginQRTimer" Margin="10,0,0,0" HorizontalAlignment="Center" VerticalAlignment="Center"/>
                         </StackPanel>
-                    </Grid>
+                    </StackPanel>
 
                     <!-- Emulator path mappings -->
                     <DockPanel Margin="0,14,0,0">

--- a/Settings/SettingsView.xaml.cs
+++ b/Settings/SettingsView.xaml.cs
@@ -216,9 +216,8 @@ namespace RomM.Settings
 
             QRVerificationPath = pairDevice.VerificationPathComplete;
 
-            LoginQRBorder.Visibility = Visibility.Visible;
             LoginQR.Background = new System.Windows.Media.ImageBrush(BuildQRCode($"{SettingsViewModel.Instance.RomMHost}{QRVerificationPath}"));
-            LoginQR.Visibility = Visibility.Visible;          
+            QRPanel.Visibility = Visibility.Visible;
             QRDetails.Visibility = Visibility.Visible;
 
             try
@@ -286,10 +285,9 @@ namespace RomM.Settings
             catch (Exception){}
             finally
             {
-                LoginQR.Visibility = Visibility.Hidden;
-                LoginQRBorder.Visibility = Visibility.Hidden;
+                QRPanel.Visibility = Visibility.Collapsed;
                 QRAuth.IsEnabled = true;
-                QRDetails.Visibility = Visibility.Hidden;
+                QRDetails.Visibility = Visibility.Collapsed;
                 QRVerificationPath = "";
             }    
         }


### PR DESCRIPTION
## Problem

When clicking **Login via QR Code**, the QR content overflowed the settings layout and overlapped the sections below it (*Emulator path mappings*, *Open in Browser*).

The QR was rendered as an absolutely-positioned `Border` overlaid on the credentials grid with `Panel.ZIndex="9999"` and a `Height` bound to its own `ActualWidth` to force a square. Because the spanned grid rows are `Auto`-height (short), the square QR painted on top of everything below it instead of reserving space — the visible overflow.

| Before |
| --- |
| QR square overlaps *Emulator path mappings* and the *Open in Browser* button |

## Fix

Restructured the Authentication section into a clean two-region layout:

- **Left** — credential fields (host, token, basic auth, username, password), unchanged in appearance.
- **Right** — a QR panel (button → QR image → *Open in Browser* + timer) that lives in the **normal layout flow** at a fixed **200×200** size.

The QR now pushes surrounding content down instead of drawing over it. Removed the `Panel.ZIndex="9999"` overlay hack and the unbounded `Height="{Binding ActualWidth}"` self-binding. Code-behind toggles a single `QRPanel` container (`Visible`/`Collapsed`) rather than flipping the two overlay borders.

## Testing

Changes are layout-only and element names line up between XAML and code-behind. This machine has no .NET toolchain (Windows/Playnite plugin), so a build + visual check on Windows is recommended to confirm the 200px sizing looks right (easy to bump if preferred larger/smaller).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*