### PR TITLE
Update avatar endpoint for RomM 5.0.0

### DIFF
--- a/Settings/Settings.cs
+++ b/Settings/Settings.cs
@@ -417,36 +417,7 @@ namespace RomM.Settings
                 // Profile (name/role/avatar) is only needed for the settings UI, not for import.
                 if (fetchProfile)
                 {
-                    // Get user info
-                    response = HttpClientSingleton.Instance.GetAsync($"{RomMHost}/api/users/me", System.Net.Http.HttpCompletionOption.ResponseContentRead, new System.Threading.CancellationTokenSource(TimeSpan.FromSeconds(30)).Token).GetAwaiter().GetResult();
-                    response.EnsureSuccessStatusCode();
-
-                    body = response.Content.ReadAsStreamAsync().GetAwaiter().GetResult();
-                    RomMUser userinfo;
-
-                    using (StreamReader reader = new StreamReader(body))
-                    {
-                        var jsonResponse = JObject.Parse(reader.ReadToEnd());
-                        userinfo = jsonResponse.ToObject<RomMUser>();
-                    }
-
-                    if (!string.IsNullOrEmpty(userinfo.IconPath))
-                    {
-                        response = HttpClientSingleton.Instance.GetAsync($"{RomMHost}/api/raw/assets/{userinfo.IconPath}", System.Net.Http.HttpCompletionOption.ResponseContentRead, new System.Threading.CancellationTokenSource(TimeSpan.FromSeconds(30)).Token).GetAwaiter().GetResult();
-                        response.EnsureSuccessStatusCode();
-                        var imagebytes = response.Content.ReadAsByteArrayAsync().GetAwaiter().GetResult();
-                        var extensionDataDir = $"{PlayniteAPI.Paths.ExtensionsDataPath}\\{RomM.Id.ToString()}";
-                        Directory.CreateDirectory(extensionDataDir);
-                        File.WriteAllBytes($"{extensionDataDir}\\avatar.png", imagebytes);
-                        ProfilePath = $"{extensionDataDir}\\avatar.png";
-                    }
-                    else
-                    {
-                        ProfilePath = _defaultprofilepath;
-                    }
-
-                    RomMProfileType = userinfo.Role;
-                    RomMUser = userinfo.Username;
+                    FetchProfileInfo();
                 }
 
                 if(UpdateNotificationBar)
@@ -469,6 +440,57 @@ namespace RomM.Settings
             }
 
             return true;
+        }
+
+        private void FetchProfileInfo()
+        {
+            try
+            {
+                // Get user info
+                var response = HttpClientSingleton.Instance.GetAsync($"{RomMHost}/api/users/me", System.Net.Http.HttpCompletionOption.ResponseContentRead, new System.Threading.CancellationTokenSource(TimeSpan.FromSeconds(30)).Token).GetAwaiter().GetResult();
+                response.EnsureSuccessStatusCode();
+
+                var body = response.Content.ReadAsStreamAsync().GetAwaiter().GetResult();
+                RomMUser userinfo;
+
+                using (StreamReader reader = new StreamReader(body))
+                {
+                    var jsonResponse = JObject.Parse(reader.ReadToEnd());
+                    userinfo = jsonResponse.ToObject<RomMUser>();
+                }
+
+                RomMProfileType = userinfo.Role;
+                RomMUser = userinfo.Username;
+
+                if (!string.IsNullOrEmpty(userinfo.IconPath))
+                {
+                    string raw = (ServerVersion ?? string.Empty).Split('-', '+')[0];
+                    if (Version.TryParse(raw, out Version parsed) && parsed.CompareTo(new Version(5, 0, 0)) <= 0)
+                    {
+                        response = HttpClientSingleton.Instance.GetAsync($"{RomMHost}/api/users/{userinfo.Id}/avatar", System.Net.Http.HttpCompletionOption.ResponseContentRead, new System.Threading.CancellationTokenSource(TimeSpan.FromSeconds(30)).Token).GetAwaiter().GetResult();
+                    }
+                    else
+                    {
+                        response = HttpClientSingleton.Instance.GetAsync($"{RomMHost}/api/raw/assets/{userinfo.IconPath}", System.Net.Http.HttpCompletionOption.ResponseContentRead, new System.Threading.CancellationTokenSource(TimeSpan.FromSeconds(30)).Token).GetAwaiter().GetResult();
+                    }
+                    response.EnsureSuccessStatusCode();
+                    var imagebytes = response.Content.ReadAsByteArrayAsync().GetAwaiter().GetResult();
+                    var extensionDataDir = $"{PlayniteAPI.Paths.ExtensionsDataPath}\\{RomM.Id.ToString()}";
+                    Directory.CreateDirectory(extensionDataDir);
+                    File.WriteAllBytes($"{extensionDataDir}\\avatar.png", imagebytes);
+                    ProfilePath = $"{extensionDataDir}\\avatar.png";
+                }
+                else
+                {
+                    ProfilePath = _defaultprofilepath;
+                }
+
+            }
+            catch (Exception ex)
+            {
+                LogManager.GetLogger().Error($"Failed to get profile info, skipping! {ex}");
+                ProfilePath = _defaultprofilepath;
+            }
         }
 
         // Fetches the RomM platform list and assigns it to RomMPlatforms, which propagates to every

--- a/Settings/Settings.cs
+++ b/Settings/Settings.cs
@@ -465,7 +465,7 @@ namespace RomM.Settings
                 if (!string.IsNullOrEmpty(userinfo.IconPath))
                 {
                     string raw = (ServerVersion ?? string.Empty).Split('-', '+')[0];
-                    if (Version.TryParse(raw, out Version parsed) && parsed.CompareTo(new Version(5, 0, 0)) <= 0)
+                    if (Version.TryParse(raw, out Version parsed) && parsed.CompareTo(new Version(5, 0, 0)) >= 0)
                     {
                         response = HttpClientSingleton.Instance.GetAsync($"{RomMHost}/api/users/{userinfo.Id}/avatar", System.Net.Http.HttpCompletionOption.ResponseContentRead, new System.Threading.CancellationTokenSource(TimeSpan.FromSeconds(30)).Token).GetAwaiter().GetResult();
                     }
@@ -489,7 +489,13 @@ namespace RomM.Settings
             catch (Exception ex)
             {
                 LogManager.GetLogger().Error($"Failed to get profile info, skipping! {ex}");
+                
+                if(File.Exists($"{PlayniteAPI.Paths.ExtensionsDataPath}\\{RomM.Id.ToString()}\\avatar.png"))
+                    File.Delete($"{PlayniteAPI.Paths.ExtensionsDataPath}\\{RomM.Id.ToString()}\\avatar.png");
+
                 ProfilePath = _defaultprofilepath;
+                RomMUser = "----";
+                RomMProfileType = "----";
             }
         }
 

--- a/Settings/SettingsView.xaml
+++ b/Settings/SettingsView.xaml
@@ -126,7 +126,15 @@
                         <TextBlock Grid.Row="1" Grid.Column="0" VerticalAlignment="Center">
                             <Hyperlink NavigateUri="{Binding ClientTokenURL}" RequestNavigate="Hyperlink_RequestNavigate">Client Token</Hyperlink>
                         </TextBlock>
-                        <TextBox Grid.Row="1" Grid.Column="1" VerticalAlignment="Center" Style="{StaticResource FieldBox}" Text="{Binding RomMClientToken, Mode=TwoWay}" />
+                        <TextBox Grid.Row="1" Grid.Column="1" VerticalAlignment="Center" Style="{StaticResource FieldBox}" Text="{Binding RomMClientToken, Mode=TwoWay}" ToolTip="Required Scopes:&#x0a;
+    me.read, me.write,&#x0a;
+    assets.read, assets.write,&#x0a;
+    devices.read, devices.write,&#x0a;
+    roms.user.read, roms.user.write,&#x0a;
+    roms.read,&#x0a;
+    platforms.read,&#x0a;
+    firmware.read,&#x0a;
+    collections.read, collections.write"/>
 
                         <CheckBox Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" Margin="0,0,0,6" VerticalAlignment="Center" Content="Use basic auth (username / password)" IsChecked="{Binding UseBasicAuth, Mode=TwoWay}" />
 

--- a/Settings/SettingsView.xaml.cs
+++ b/Settings/SettingsView.xaml.cs
@@ -23,7 +23,6 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Media;
 using System.Windows.Media.Imaging;
 
 namespace RomM.Settings


### PR DESCRIPTION
- Updated endpoint to `/api/users/{Id}/avatar`
- Placed pulling profile info in try catch, should prevent future endpoint changes from voiding authentication attempt
- Added required scopes to client token textbox tooltip