### PR TITLE
Fix typos in comments, README, and addon manifests

### DIFF
--- a/Downloads/SidebarItemControl.cs
+++ b/Downloads/SidebarItemControl.cs
@@ -40,7 +40,7 @@ namespace RomM.Downloads
                 FontSize = 18
             };
 
-            // Link contener
+            // Link container
             StackPanel stackPanel = new StackPanel
             {
                 Orientation = Orientation.Horizontal,

--- a/Games/RomMImport.cs
+++ b/Games/RomMImport.cs
@@ -107,7 +107,7 @@ namespace RomM.Games
                         continue;
                     }
 
-                    // Fail-safe incase none of these are set to true
+                    // Fail-safe in case none of these are set to true
                     if (!ROM.HasSimpleSingleFile & !ROM.HasNestedSingleFile & !ROM.HasMultipleFiles)
                         ROM.HasMultipleFiles = true;
 

--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@
 
 # Overview
 
-This plugin allows you to import your RomM library into Playnite. It queries the RomM API to create Playnite library entires for each of your games. Installing a game in Playnite will download it from RomM and store it on your system, allowing you to launch it in your emulator of choice.
+This plugin allows you to import your RomM library into Playnite. It queries the RomM API to create Playnite library entries for each of your games. Installing a game in Playnite will download it from RomM and store it on your system, allowing you to launch it in your emulator of choice.
 
 > [!WARNING]
-> The plugin requires a RomM instance setup with IGDB API credentials, otherwise it won't work. You can find more information on how to set generate and set credentials in the [docs](https://docs.romm.app/latest/Getting-Started/Generate-API-Keys/).
+> The plugin requires a RomM instance set up with IGDB API credentials, otherwise it won't work. You can find more information on how to generate and set credentials in the [docs](https://docs.romm.app/latest/Getting-Started/Generate-API-Keys/).
 
 # Installation
 

--- a/RomM.cs
+++ b/RomM.cs
@@ -424,7 +424,7 @@ namespace RomM
                         Mapping = Settings.Mappings.FirstOrDefault(x => x.MappingId == gameData.MappingID)
                     };
 
-                    // If Siblings are avaiable prompt user with version selection
+                    // If Siblings are available prompt user with version selection
                     if (Settings.MergeRevisions && gameData.ROMVersions?.Count > 1)
                     {
 

--- a/manifests/addon.yaml
+++ b/manifests/addon.yaml
@@ -6,7 +6,7 @@ ShortDescription: Import your RomM library into Playnite
 InstallerManifestUrl: https://raw.githubusercontent.com/rommapp/playnite-plugin/main/manifests/installer.yaml
 SourceUrl: https://github.com/rommapp/playnite-plugin
 Description: |
-  This plugin allows you to import your RomM library into Playnite. It queries the RomM API to create Playnite library entires for each of your games.
+  This plugin allows you to import your RomM library into Playnite. It queries the RomM API to create Playnite library entries for each of your games.
 
   Installing a game in Playnite will download it from RomM and store it on your system, allowing you to launch it in your emulator of choice.
 Tags: [romm, emulation, retro]

--- a/manifests/installer.yaml
+++ b/manifests/installer.yaml
@@ -66,7 +66,7 @@ Packages:
     ReleaseDate: 2025-06-05
     PackageUrl: https://github.com/rommapp/playnite-plugin/releases/download/0.4.0/RomM_9700aa21-447d-41b4-a989-acd38f407d9f_0_4_0.pext
     Changelog:
-      - Fetch games in pagniated chunks of 72 to avoid timeouts
+      - Fetch games in paginated chunks of 72 to avoid timeouts
   - Version: 0.4.1
     RequiredApiVersion: 6.13.0
     ReleaseDate: 2025-11-28


### PR DESCRIPTION
## Summary

Seven single-word spelling/wording fixes. No identifiers, no API surface, no behaviour changes.

### Comments
- **Downloads/SidebarItemControl.cs**: `// Link contener` -> `// Link container`
- **RomM.cs**: `// If Siblings are avaiable prompt user` -> `available`
- **Games/RomMImport.cs**: `// Fail-safe incase none of these are set to true` -> `in case`

### User-facing text
- **README.md**: `create Playnite library entires` -> `entries`
- **README.md**: `requires a RomM instance setup with IGDB API credentials` -> `set up with` (verb, not noun)
- **README.md**: `how to set generate and set credentials` -> `how to generate and set credentials` (stray duplicated `set`)
- **manifests/addon.yaml**: same `entires` -> `entries` in the add-on description shown in Playnite's browser
- **manifests/installer.yaml**: `Fetch games in pagniated chunks of 72` -> `paginated` (0.4.0 changelog entry). Drop this hunk if you would rather leave a shipped changelog entry untouched.

### Deliberately NOT changed
- `PART_GridContener` in `Downloads/SidebarItemControl.cs` is misspelled, but it is a private property referenced in four places - renaming it is a code change, not a typo fix, so it is left for you to decide.
- `SiderbarItemType` in `Downloads/RomMDownloadsSidebarItem .cs` is spelled that way because that is the actual enum name in the Playnite SDK (`PlayniteSDK/Plugins/SidebarItem.cs`). "Correcting" it would not compile.
- The `// ... revert any changes made to Option1 and Option2` comments in `Settings/Settings.cs` are Playnite's `ISettings` template boilerplate and reference example names that do not exist here; rewriting them is a judgement call for a maintainer, not a typo fix.
- British spellings throughout (`normalise`, `initialises`, `centralises`, `honour`, `favourites`, `centre`, `modelled`) are consistent repo-wide and were left alone.